### PR TITLE
US12787: Add Collections For Author & Topic

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,8 @@ description: No matter what your beliefs, you are welcome here.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://www.crossroads.net" # the base hostname & protocol for your site, e.g. http://example.com
 
+permalink: pretty
+
 markdown: kramdown
 plugins:
   - jekyll-feed
@@ -25,6 +27,8 @@ exclude:
 include:
   - _redirects
 
+collections_dir: collections
+
 collections:
   topics:
     output: true
@@ -32,8 +36,6 @@ collections:
   authors:
     output: true
     permalink: /authors/:path/
-
-collections_dir: collections
 
 defaults:
   - scope:

--- a/_config.yml
+++ b/_config.yml
@@ -24,3 +24,25 @@ exclude:
 
 include:
   - _redirects
+
+collections:
+  topics:
+    output: true
+    permalink: /topics/:path/
+  authors:
+    output: true
+    permalink: /authors/:path/
+
+collections_dir: collections
+
+defaults:
+  - scope:
+      path: "/topics/"
+      type: topics
+    values:
+      layout: topic
+  - scope:
+      path: "/authors/"
+      type: authors
+    values:
+      layout: author

--- a/_includes/_article-header.html
+++ b/_includes/_article-header.html
@@ -7,10 +7,10 @@
             </h5> -->
       <h2 class="publication_title section-header flush-top push-half-bottom">{{ page.title | escape }}</h2>
       <div>
-        <span class="publication_series text-gray-light">{{ page.author.full_name }}</span> |
+        <span class="publication_series text-gray-light">{{ page.author }}</span> |
         <span class="article_date">
           {% assign date_format = site.crds-media.date_format | default: "%b %-d, %Y" %}
-          {{ page.published_date | date: date_format }}
+          {{ page.date | date: date_format }}
         </span>
       </div>
     </div>

--- a/_includes/_article-header.html
+++ b/_includes/_article-header.html
@@ -1,13 +1,12 @@
+{% assign author = site.authors | where:"name", page.author | first %}
+
 <div class="publication_header push-top">
   <div class="container">
     <div class="col-md-6 col-md-offset-3">
-      <!--
-            <h5 class="publication_meta metadata flush"><%= assigns[:article]["topic"] %> -
-                <span class="publication_duration"><%= assigns[:article]["duration"] %></span>
-            </h5> -->
+      <h5 class="publication_meta metadata flush">{{ page.topic }}</h5>
       <h2 class="publication_title section-header flush-top push-half-bottom">{{ page.title | escape }}</h2>
       <div>
-        <span class="publication_series text-gray-light">{{ page.author }}</span> |
+        <a href="{{ author.permalink }}">{{ page.author }}</a> |
         <span class="article_date">
           {% assign date_format = site.crds-media.date_format | default: "%b %-d, %Y" %}
           {{ page.date | date: date_format }}

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -1,0 +1,38 @@
+---
+layout: default
+---
+{% assign author_name = page.name %}
+{% assign author_bio = page.content %}
+{% assign author_img = page.image %}
+
+<div class="container">
+  <div class="media push-bottom">
+    <div class="media-img-wrapper" style="align-items: center;">
+      <img class="media-object-default img-circle media-object img-size-5" src="{{ author_img }}" />
+    </div>
+    <div class="media-body" style="max-width: 640px;">
+      <h2 class="component-header">{{ author_name }}</h2>
+      {{ author_bio }}
+    </div>
+  </div>
+
+  <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
+    {% for post in site.posts %}
+      {% if post.author == author_name %}
+        <div class="card card--article">
+          <a href="{{ post.url }}">
+            <div class="card-bgImage sixteen-nine" style="background-image: url('{{ post.featured_image }}');"></div>
+            <div class="card-block">
+              <h4 class="card-title font-family-condensed-extra text-uppercase">{{ post.title }}</h4>
+              <p class="card-text"><a class="card-author">{{ post.author }}</a> |
+                <span class="card-date">
+                  {{ post.date | date: date_format }}
+                </span>
+              </p>
+            </div>
+          </a>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+</div>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -5,6 +5,8 @@ layout: default
 {% assign author_bio = page.content %}
 {% assign author_img = page.image %}
 
+{% assign date_format = site.crds-media.date_format | default: "%b %-d, %Y" %}
+
 <div class="container">
   <div class="media push-bottom">
     <div class="media-img-wrapper" style="align-items: center;">

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -19,9 +19,9 @@ layout: default
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
     {% for post in site.posts %}
       {% if post.author == author_name %}
-        <div class="card card--article">
+        <div class="card card--layered">
           <a href="{{ post.url }}">
-            <div class="card-bgImage sixteen-nine" style="background-image: url('{{ post.featured_image }}');"></div>
+            <div class="card-bgImage sixteen-nine bgCenter" style="background-image: url('{{ post.featured_image }}');"></div>
             <div class="card-block">
               <h4 class="card-title font-family-condensed-extra text-uppercase">{{ post.title }}</h4>
               <p class="card-text"><a class="card-author">{{ post.author }}</a> |

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,5 +2,5 @@
 layout: default
 ---
 
-{% include _publication-header.html %}
+{% include _article-header.html %}
 {% include _article-body.html %}

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -1,5 +1,26 @@
 ---
 layout: default
 ---
-
-I'm a topic page
+{% assign topic_name = page.name %}
+<div class="container">
+  <h2 class="section-header">{{ topic_name }}</h2>
+  <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
+    {% for post in site.posts %}
+      {% if post.topic == topic_name %}
+        <div class="card card--layered">
+          <a href="{{ post.url }}">
+            <div class="card-bgImage sixteen-nine bgCenter" style="background-image: url('{{ post.featured_image }}');"></div>
+            <div class="card-block">
+              <h4 class="card-title font-family-condensed-extra text-uppercase">{{ post.title }}</h4>
+              <p class="card-text"><a class="card-author">{{ post.author }}</a> |
+                <span class="card-date">
+                  {{ post.date | date: date_format }}
+                </span>
+              </p>
+            </div>
+          </a>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+</div>

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+I'm a topic page

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -1,7 +1,10 @@
 ---
 layout: default
 ---
+
 {% assign topic_name = page.name %}
+{% assign date_format = site.crds-media.date_format | default: "%b %-d, %Y" %}
+
 <div class="container">
   <h2 class="section-header">{{ topic_name }}</h2>
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">

--- a/_plugins/hubspot_generator.rb
+++ b/_plugins/hubspot_generator.rb
@@ -30,8 +30,8 @@ module Jekyll
         doc.data['date'] = published_at
         doc.data['slug'] = slug
         doc.data['featured_image'] = post['featured_image']
-        doc.data['author'] = post['author_name']
-
+        doc.data['author'] = post['blog_post_author']['display_name']
+        
         site.posts.docs << doc
       end
 

--- a/_scss/_custom.scss
+++ b/_scss/_custom.scss
@@ -91,15 +91,19 @@
   }
 }
 
-.card--article {
-  .card-bgImage {
-    width: 100%;
-    // keep at 16/9 aspect ratio
+.card-bgImage {
+  width: 100%;
+  background-size: cover;
+  &.sixteen-nine {
     padding-bottom: 56.25%;
-    background-size: cover;
+    height: 0;
+  }
+  &.bgCenter {
     background-position: center;
   }
-  
+}
+
+.card--article {
   .card-block {
     padding: .5rem;
     margin-right: 2rem;

--- a/_scss/_custom.scss
+++ b/_scss/_custom.scss
@@ -90,20 +90,20 @@
     padding-bottom: 280px;
   }
 }
+.card--layered {
 
-.card-bgImage {
-  width: 100%;
-  background-size: cover;
-  &.sixteen-nine {
-    padding-bottom: 56.25%;
-    height: 0;
+  .card-bgImage {
+    width: 100%;
+    background-size: cover;
+    &.sixteen-nine {
+      padding-bottom: 56.25%;
+      height: 0;
+    }
+    &.bgCenter {
+      background-position: center;
+    }
   }
-  &.bgCenter {
-    background-position: center;
-  }
-}
 
-.card--article {
   .card-block {
     padding: .5rem;
     margin-right: 2rem;
@@ -132,7 +132,7 @@
   }
 }
 
-.card-deck--expanded-layout .card--article {
+.card-deck--expanded-layout .card--layered {
   margin-bottom: 0;
 
   @media (min-width: 570px) {

--- a/authors.md
+++ b/authors.md
@@ -1,6 +1,5 @@
 ---
 layout: default
-permalink: /authors/index.html
 ---
 
 <div class="container">
@@ -8,7 +7,7 @@ permalink: /authors/index.html
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
     {% for author in site.authors %}
     <div class="card card--layered">
-        <a href="/authors/{{ author.link }}">
+        <a href="{{ author.permalink }}">
           <div class="card-bgImage sixteen-nine" style="background-image: url('{{ author.image }}');"></div>
           <div class="card-block">
             <h4 class="card-title text-uppercase font-family-condensed-extra">{{ author.name }}</h4>

--- a/authors.md
+++ b/authors.md
@@ -7,12 +7,12 @@ permalink: /authors/index.html
   <h2 class="section-header">Authors</h2>
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
     {% for author in site.authors %}
-    <div class="card">
+    <div class="card card--layered">
         <a href="/authors/{{ author.link }}">
           <div class="card-bgImage sixteen-nine" style="background-image: url('{{ author.image }}');"></div>
           <div class="card-block">
-            <h4 class="card-title">{{ author.name }}</h4>
-            <h5 class="card-subtitle">{{ author.post_amount }} articles</h5>
+            <h4 class="card-title text-uppercase font-family-condensed-extra">{{ author.name }}</h4>
+            <h5 class="card-subtitle">{{ author.posts }} articles</h5>
           </div>
         </a>
       </div>

--- a/authors.md
+++ b/authors.md
@@ -1,0 +1,21 @@
+---
+layout: default
+permalink: /authors/index.html
+---
+
+<div class="container">
+  <h2 class="section-header">Authors</h2>
+  <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
+    {% for author in site.authors %}
+    <div class="card">
+        <a href="/authors/{{ author.link }}">
+          <div class="card-bgImage sixteen-nine" style="background-image: url('{{ author.image }}');"></div>
+          <div class="card-block">
+            <h4 class="card-title">{{ author.name }}</h4>
+            <h5 class="card-subtitle">{{ author.post_amount }} articles</h5>
+          </div>
+        </a>
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/collections/_authors/alli-patterson.md
+++ b/collections/_authors/alli-patterson.md
@@ -1,0 +1,9 @@
+---
+layout: author
+permalink: /authors/alli-patterson/
+name: Alli Patterson
+posts: 
+image: https://miro.medium.com/fit/c/160/160/1*VH4PhuOBHfSnF3tZ6VD1Zw.jpeg
+---
+
+Writer, Wife and Mom of 4, Runner, seminary student, Despiser of small talk, Commissioned Pastor at Crossroads, The-one-who-always-asks-“why,” Nerd at heart.

--- a/collections/_authors/brian-tome.md
+++ b/collections/_authors/brian-tome.md
@@ -1,7 +1,7 @@
 ---
 layout: author
+permalink: /authors/brian-tome/
 name: Brian Tome
-link: brian-tome/
 posts: 1
 image: https://miro.medium.com/fit/c/160/160/1*cSAYRIzpcfpWgat5fKXhgw.jpeg
 ---

--- a/collections/_authors/brian-tome.md
+++ b/collections/_authors/brian-tome.md
@@ -2,7 +2,7 @@
 layout: author
 name: Brian Tome
 link: brian-tome/
-post_amount: 1
+posts: 1
 image: https://miro.medium.com/fit/c/160/160/1*cSAYRIzpcfpWgat5fKXhgw.jpeg
 ---
 

--- a/collections/_authors/brian-tome.md
+++ b/collections/_authors/brian-tome.md
@@ -1,0 +1,9 @@
+---
+layout: author
+name: Brian Tome
+link: brian-tome/
+post_amount: 1
+image: https://miro.medium.com/fit/c/160/160/1*cSAYRIzpcfpWgat5fKXhgw.jpeg
+---
+
+Adventure Rider, Senior Pastor of Crossroads Church, Husband, Father, Author, Equal Opportunity Offender/Encourager.

--- a/collections/_authors/caleb-mathis.md
+++ b/collections/_authors/caleb-mathis.md
@@ -1,0 +1,9 @@
+---
+layout: author
+permalink: /authors/caleb-mathis/
+name: Caleb Mathis
+posts: 
+image: https://miro.medium.com/fit/c/160/160/1*KX-07zb9abyDKPOdqN7RDQ.png
+---
+
+Dad of three, husband of one, pastor @crdschurch, and at the moment would rather be reading Tolkien, watching British TV, or in a pub with a pint of Guinness.

--- a/collections/_authors/rob-seddon.md
+++ b/collections/_authors/rob-seddon.md
@@ -1,7 +1,7 @@
 ---
 layout: author
+permalink: /authors/rob-seddon/
 name: Rob Seddon
-link: rob-seddon/
 posts: 0
 image: https://miro.medium.com/fit/c/160/160/1*PlLSyU1L2w0KTqlBDwqNDA.jpeg
 ---

--- a/collections/_authors/rob-seddon.md
+++ b/collections/_authors/rob-seddon.md
@@ -1,0 +1,9 @@
+---
+layout: author
+name: Rob Seddon
+link: rob-seddon/
+post_amount: 0
+image: https://miro.medium.com/fit/c/160/160/1*PlLSyU1L2w0KTqlBDwqNDA.jpeg
+---
+
+Husband, Father of (many) daughters, Small town kid who got to travel the world, Browns fan (still), Believer, Reader, Fears pigeons and other people’s kids.

--- a/collections/_authors/rob-seddon.md
+++ b/collections/_authors/rob-seddon.md
@@ -2,7 +2,7 @@
 layout: author
 name: Rob Seddon
 link: rob-seddon/
-post_amount: 0
+posts: 0
 image: https://miro.medium.com/fit/c/160/160/1*PlLSyU1L2w0KTqlBDwqNDA.jpeg
 ---
 

--- a/collections/_posts/2018-03-22-money.md
+++ b/collections/_posts/2018-03-22-money.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: That one post about money
+author: Brian Tome
+topic: money
+featured_image: https://images.unsplash.com/photo-1494888427482-242d32babc0b?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=a689c51340e923fd138d8f3b5f578110&auto=format&fit=crop&w=750&q=80
+---
+
+This is a sample post about money. It isn't very long.

--- a/collections/_posts/2018-03-22-my-family.md
+++ b/collections/_posts/2018-03-22-my-family.md
@@ -1,0 +1,54 @@
+---
+layout: post
+title: My Amazing Family
+author: Rob Seddon
+topic: family
+featured_image: https://images.unsplash.com/photo-1502629604127-8786e918dd97?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=45de56689428aaf7185b54695e37f76f&auto=format&fit=crop&w=1350&q=80
+---
+
+We are being misled. There’s a massive fraud being exercised on all of Western humanity. It started with Shakespeare in Hamlet, and it is now a required charge in every celebrity commencement address that wasn’t canceled by campus protests. It’s the backbone of every advice column, and every conversation with a friend who just can’t figure out what to do next. And the key to having a great 2018 is to recognize it and kick it to the curb.
+
+
+This monster is the call to “be true to yourself!” (BTTYS) Or, as Shakespeare put it, “To thine own self be true.”
+
+Yes, it sounds enlightened to say, and it’s well-meaning, but that phrase ringing in the back of our minds consistently leads to frustration and chaos. It causes us to step all over other people. It’s why most of us feel so stuck. And it needs to go. Instead, there’s a better way that many people of faith have known for thousands of years.
+
+First, let’s be honest and acknowledge that no one agrees on what BTTYS means. Nowadays, most would probably answer it means to be “authentic.” But, we’re also clueless as to what that means. Depending on the translator, it could at any time have something to do with one’s feelings, thoughts, self-interest, conscience, beliefs or values. All decent things, but none worthy of anchoring your life to. Let’s explore the ramifications of those.
+
+If BTTYS means to “be true to your feelings,” that’s a recipe for total dysfunction. Our feelings change minute by minute. In the last ten minutes I’ve felt loved, rejected, confident, fearful, confused, proud, hopeful and like a complete loser. And that was just in trying to write these opening paragraphs (and walking to the bathroom in the coffee shop where I’m sitting.) Where in there is something I can be true to on a consistent basis? For the record, whether they say it or not, this is what most people are referring to when they proclaim BTTYS. “Do what you feel is right!” That’s a recipe for disaster. The Hunger Games is just a step or two away.
+
+If BTTYS means to “be true to your thoughts,” that’s not much better. My thoughts are all over the place. Currently I’m wondering, “Who buys the gas in the middle pump?” while trying to write something meaningful.
+
+If we’re talking “be true to your self-interest,” that’s fine until my self-interest and someone else’s self-interest conflict, basically eliminating marriage or parenting from the world.
+
+If it’s “be true to your conscience,” now we’re at least getting somewhere, since the Bible recognizes the power of a good conscience. Our conscience can at least help us avoid some bad decisions. But, the Bible also talks about an evil conscience, so we have that to wrestle with. And, I’m not certain in my ability to completely separate my conscience from my feelings, so I’m pretty sure if I consistently follow my conscience I’ll sometimes be following my ever-changing, self-interested feelings, getting me back to where I started.
+
+If “be true to my beliefs” is the focus, I have to admit that I regularly don’t know exactly what I believe, and often when I do know, those beliefs turn out to be wrong. I once believed I could lose weight by maintaining all of my current eating habits and simply drinking a lot more water. I just peed a lot. I still believe my Cleveland Browns fandom will lead to good things. You think (know) I’m delusional. I believe deeply in Jesus as the Son of God, and worthy of everything I have, but I don’t always act that way. One of the most powerful prayers in the Bible is when a father comes to Jesus and says, “I believe, help me in my unbelief.” That’s me. Every day. The totality of my beliefs are not an anchorpoint.
+
+Finally, if the BTTYS mandate is for one to “be true to your values,” then, like my beliefs, I have to know what I value. And I’ll be the first to admit that my values can change based on my self-interest. I had a value that I would never, ever pick up a Pittsburgh Steeler in fantasy football, until last month when I made the championship round, $350 was on the line, I badly needed a defense, and Pitt was playing the lowly Houston Texans offense. I caved. And lost anyway.
+
+I’m convinced most of the people elected to the U.S. Congress are good people who mean what they say they value when they run for election. But, we all see what happens when they get placed into the pressure cooker on the Hill. Their only value becomes re-election. And we hate them.
+
+We are not consistent beings. We need to acknowledge that and stop misleading ourselves by thinking we can be true to something that changes all the time. Besides, let’s preserve our ability to grow. I’m an adult man with a lot of experience and two college degrees, but I know I can still change and get better. I would never tell my seven year old daughter to be true to herself. She’d spend all her energy trying to create polyjuice potion and eating mac and cheese. I want her to grow in wisdom. And, unless you’re arrogant enough to believe you have nothing left to learn, you should want that for yourself too. I do.
+
+If we want to get somewhere, we have to be true to something that will never change, even if it’s not authentic to ourselves at that moment. When you run a marathon, you can be certain the finish line will be where you left it. It’s what makes the chafing endurable. But what if they moved the finish line every 15 minutes? You’d stop running. Immediately.
+
+God knows we are in this predicament of having nothing internal to moor our lives to. So He asks us to consider tying ourselves to Him. When King David, one of the greatest kings in the history of Ancient Israel, is about to die, he passes on some wisdom to his son, Solomon. He tells him:
+
+…Be strong, and show yourself a man, and keep the charge of the Lord your God, walking in his ways and keeping his statutes, his commandments, his rules, and his testimonies, as it is written in the Law of Moses, that you may prosper in all that you do and wherever you turn, that the Lord may establish his word that he spoke concerning me, saying, ‘If your sons pay close attention to their way, to walk before me in faithfulness with all their heart and with all their soul, you shall not lack a man on the throne of Israel.’ 1 Kings 2:2–4
+
+David wants nothing more than a strong legacy, and he knows it’s possible if his son is not true to himself, but is instead true to God. He tells his son that to be a man means to do what God wants and says. And Solomon follows this advice, for awhile, and becomes great, until he eventually goes his own way, is true to himself, and brings about destruction of the unified kingdom.
+
+David’s advice is great, and we have it better than Solomon, because God made it easier for us to be true to Him by sending Jesus — God with us. That’s literally His name. God gave us a real-life example that doesn’t change that we can anchor to. For thousands of years, critics have tried to tear Jesus apart. He’s still here. We still celebrated Christmas last month. Billions of people celebrated actually.
+
+We can look at how Jesus thought, what he believed, what he felt, what he valued, and go that way. Yes, even when it conflicts with what we want at the moment. We’ll have to do some things that are initially uncomfortable, but any person who has faithfully put this plan into motion will tell you that he/she found tremendous fruit on the other side. And, there’s great freedom to be found when you can stop spending every waking minute trying to figure out who you are and what you believe and value, because it no longer matters. You can go for a walk instead. Or go to a movie.
+
+So, my advice is:
+
+Stop saying BTTYS.
+Stop believing BTTYS is the answer.
+Start looking for something/someone better than yourself to be true to.
+Ask yourself everyday, “Am I being true to that person/thing?”
+If that person is not Jesus, OK, but good luck finding someone as consistent, fruitful, powerful, and life-giving. There’s a reason billions of people have gone His way over many millennia (and have changed the freakin world in the process), and there’s a reason the worldly passions and crushes of every decade of our lives consistently fade away.
+
+Every time this year that I have a question about what to do or where to go, I hope I’m not true to myself, but I’m true to something much better than myself. That’s how we go to new places.

--- a/collections/_topics/family.md
+++ b/collections/_topics/family.md
@@ -1,0 +1,9 @@
+---
+layout: topic
+name: family
+link: family/
+image: https://images.unsplash.com/photo-1497486751825-1233686d5d80?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2e35a7cbfb796c332cd8034e4e341d89&auto=format&fit=crop&w=1301&q=80
+posts: 1
+---
+
+Family. We've all got 'em.

--- a/collections/_topics/money.md
+++ b/collections/_topics/money.md
@@ -3,6 +3,7 @@ layout: topic
 name: money
 link: money/
 image: https://images.unsplash.com/photo-1500496733680-167c3db69389?ixlib=rb-0.3.5&s=0bb120921b4af2e0dcd01aa082aee04a&auto=format&fit=crop&w=1239&q=80
+posts: 1
 ---
 
 Money. It's crazy complicated.

--- a/collections/_topics/money.md
+++ b/collections/_topics/money.md
@@ -1,0 +1,8 @@
+---
+layout: topic
+name: money
+link: money/
+image: https://images.unsplash.com/photo-1500496733680-167c3db69389?ixlib=rb-0.3.5&s=0bb120921b4af2e0dcd01aa082aee04a&auto=format&fit=crop&w=1239&q=80
+---
+
+Money. It's crazy complicated.

--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 ---
 layout: default
+heading: Fresh, Hot Words Written For You
+subheading: Welcome to the information buffet. Reading is free, but taking action is gonna cost you. Dig in.
 ---
 <div class="jumbotron jumbotron--tall bg-blue">
   <div class="container">
@@ -12,16 +14,16 @@ layout: default
   {% assign date_format = site.crds-media.date_format | default: "%b %-d, %Y" %}
   {% assign sorted = site.posts %}
   {% assign featured = sorted | first %}
+  {% assign featured_author = site.authors | where:"name", featured.author | first %}
   {% assign unfeatured = sorted | slice:1, sorted.size %}
+
   <div class="card card--layered card--feature">
     <a href="{{ featured.url }}">
       <div class="card-bgImage bgCenter" style="background-image: url('{{ featured.featured_image }}');"></div>
       <div class="card-block">
         <h4 class="card-title font-family-condensed-extra text-uppercase">{{ featured.title }}</h4>
         <p class="card-text soft-quarter-top flush-bottom">
-          <a class="card-author">
-            {{ featured.author }}
-          </a> |
+          <a href="{{ featured_author.permalink }}">{{ featured.author }}</a> |
           <span class="card-date">
               {{ featured.date | date: date_format }}
           </span>
@@ -31,12 +33,14 @@ layout: default
   </div>
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
     {% for post in unfeatured %}
+      {% assign author = site.authors | where:"name", post.author | first %}
       <div class="card card--layered">
         <a href="{{ post.url }}">
           <div class="card-bgImage sixteen-nine" style="background-image: url('{{ post.featured_image }}');"></div>
           <div class="card-block">
             <h4 class="card-title font-family-condensed-extra text-uppercase">{{ post.title }}</h4>
-            <p class="card-text"><a class="card-author">{{ post.author }}</a> |
+            <p class="card-text">
+              <a href="{{ author.permalink }}">{{ post.author }}</a> |
               <span class="card-date">
                 {{ post.date | date: date_format }}
               </span>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ layout: default
   {% assign sorted = site.posts %}
   {% assign featured = sorted | first %}
   {% assign unfeatured = sorted | slice:1, sorted.size %}
-  <div class="card card--article card--feature">
+  <div class="card card--layered card--feature">
     <a href="{{ featured.url }}">
       <div class="card-bgImage bgCenter" style="background-image: url('{{ featured.featured_image }}');"></div>
       <div class="card-block">
@@ -31,7 +31,7 @@ layout: default
   </div>
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
     {% for post in unfeatured %}
-      <div class="card card--article">
+      <div class="card card--layered">
         <a href="{{ post.url }}">
           <div class="card-bgImage sixteen-nine" style="background-image: url('{{ post.featured_image }}');"></div>
           <div class="card-block">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ layout: default
   {% assign unfeatured = sorted | slice:1, sorted.size %}
   <div class="card card--article card--feature">
     <a href="{{ featured.url }}">
-      <div class="card-bgImage" style="background-image: url('{{ featured.featured_image }}');"></div>
+      <div class="card-bgImage bgCenter" style="background-image: url('{{ featured.featured_image }}');"></div>
       <div class="card-block">
         <h4 class="card-title font-family-condensed-extra text-uppercase">{{ featured.title }}</h4>
         <p class="card-text soft-quarter-top flush-bottom">
@@ -33,7 +33,7 @@ layout: default
     {% for post in unfeatured %}
       <div class="card card--article">
         <a href="{{ post.url }}">
-          <div class="card-bgImage" style="background-image: url('{{ post.featured_image }}');"></div>
+          <div class="card-bgImage sixteen-nine" style="background-image: url('{{ post.featured_image }}');"></div>
           <div class="card-block">
             <h4 class="card-title font-family-condensed-extra text-uppercase">{{ post.title }}</h4>
             <p class="card-text"><a class="card-author">{{ post.author }}</a> |

--- a/topics.md
+++ b/topics.md
@@ -7,11 +7,14 @@ permalink: /topics/index.html
   <h2 class="section-header">Topics</h2>
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
     {% for topic in site.topics %}
-      <div class="card">
+      <div class="card card--layered">
         <a href="/topics/{{ topic.link }}">
-          <div class="card-bgImage sixteen-nine" style="background-image: url('{{ topic.image }}');"></div>
+          <div class="card-bgImage sixteen-nine bgCenter" style="background-image: url('{{ topic.image }}');"></div>
           <div class="card-block">
-            <h4 class="card-title font-family-condensed-extra text-uppercase">{{ topic.name }}</h4>
+            <h4 class="card-title font-family-condensed-extra text-uppercase">
+              {{ topic.name }}
+            </h4>
+            <h5 class="card-subtitle">{{ topic.posts }} articles</h5>
           </div>
         </a>
       </div>

--- a/topics.md
+++ b/topics.md
@@ -1,0 +1,22 @@
+---
+layout: default
+permalink: /topics/index.html
+---
+
+<div class="container">
+  <h2 class="section-header">Topics</h2>
+  <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
+    {% for topic in site.topics %}
+      <div class="card">
+        <a href="/topics/{{ topic.link }}">
+          <div class="card-bgImage sixteen-nine" style="background-image: url('{{ topic.image }}');"></div>
+          <div class="card-block">
+            <h4 class="card-title font-family-condensed-extra text-uppercase">{{ topic.name }}</h4>
+          </div>
+        </a>
+      </div>
+    {% endfor %}
+  </div>
+</div>
+
+  


### PR DESCRIPTION
Sets up the following:
- collections for authors and topics (high level categories)
- creates /authors and /topics pages
- creates individual author/topic page where all categorized content lives
- links author names to their respective pages
- gets correct author name from the Hubspot Gen
