### PR TITLE
DE5202: Fix author link on cards

### DIFF
--- a/_includes/_article-card.html
+++ b/_includes/_article-card.html
@@ -1,9 +1,15 @@
+{% if include.content_type %}
+  {% assign author = site.authors | where:"name", include.content_type.author | first %}
+  {% assign topic = site.blogs | where:"title", include.content_type.blog | first %}
+{% endif %}
+
 <div class="card card--layered">
   <a href="{{ post.url }}">
     <div class="card-bgImage sixteen-nine" style="background-image: url('{{ post.featured_image }}');"></div>
     <div class="card-block">
-        <h5 class="article_meta metadata flush">
-          {% include _read-time.html content=post.content %}
+        <h5 class="card-meta metadata push-quarter-ends">
+          <a href="{{ topic.url }}">{{ topic.title }}</a> -
+          {% include _read-time.html content_type=post %}
         </h5>
       <h4 class="card-title font-family-condensed-extra text-uppercase">{{ post.title }}</h4>
       <p class="card-text">

--- a/_includes/_article-header.html
+++ b/_includes/_article-header.html
@@ -1,10 +1,9 @@
 {% assign author = site.authors | where:"name", page.author | first %}
-
 <div class="article_header push-top">
   <div class="container">
     <div class="col-md-8 col-md-offset-2">
       <h5 class="article_meta metadata flush">
-        {% include _read-time.html content=page.content %}
+        {% include _read-time.html content_type=page %}
       </h5>
       <h2 class="article_title section-header flush-top push-half-bottom">{{ page.title | escape }}</h2>
       <div>

--- a/_includes/_read-time.html
+++ b/_includes/_read-time.html
@@ -1,5 +1,5 @@
-{% assign words = include.content | number_of_words %}
+{% assign words = include.content_type.content | number_of_words %}
 {% assign read_time = words | divided_by: 184 %}
 {% if read_time > 0 %}
-  <span class="read-time font-size-smaller push-quarter-ends">{{ read_time }} minute read</span>
+  <span class="read-time font-size-smaller push-quarter-ends">{{ read_time }} min read</span>
 {% endif %}

--- a/_includes/_recent-articles.html
+++ b/_includes/_recent-articles.html
@@ -2,22 +2,8 @@
   <h2 class="collection-header push-bottom">recent articles</h2>
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
     {% for post in site.posts | limit:4 %}
-      {% assign author = site.authors | where:"name", post.author | first %}
       {% if page.index != post.index %}
-        <div class="card card--layered">
-          <a href="{{ post.url }}">
-            <div class="card-bgImage sixteen-nine" style="background-image: url('{{ post.featured_image }}');"></div>
-            <div class="card-block">
-              <h4 class="card-title font-family-condensed-extra text-uppercase">{{ post.title }}</h4>
-              <p class="card-text">
-                <a href="{{ author.permalink }}">{{ post.author }}</a> |
-                <span class="card-date">
-                  {{ post.date | date: date_format }}
-                </span>
-              </p>
-            </div>
-          </a>
-        </div>
+        {% include _article-card.html content_type=post %}
       {% else %}
       {% assign fifth = site.posts[5] %}
         <div class="card card--layered">

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 ---
-{% assign topic = site.blogs | where:"title", page.title | first %}
 {% assign date_format = site.crds-media.date_format | default: "%b %-d, %Y" %}
 
 <div class="container">
@@ -9,7 +8,7 @@ layout: default
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
     {% for post in site.posts %}
       {% if post.blog == page.title %}
-        {% include _article-card.html %}
+        {% include _article-card.html content_type=post %}
       {% endif %}
     {% endfor %}
   </div>

--- a/index.html
+++ b/index.html
@@ -17,8 +17,7 @@ subheading: Welcome to the information buffet. Reading is free, but taking actio
 <div class="container">
   <div data-card-deck class="card-deck card-deck--expanded-layout card-deck--wrap">
     {% for post in paginator.posts %}
-      {% assign author = site.authors | where:"name", post.author | first %}
-      {% include _article-card.html %}
+      {% include _article-card.html content_type=post %}
     {% endfor %}
   </div>
   {% include _pagination.html %}


### PR DESCRIPTION
_Context_
Because we are sharing the `_article-card` include around, sometimes the content type changes (post vs page). Sometimes author links were broken due to this.

_What this PR includes_
- refactored article card with the hope to make it more sharable
- adds topic/category to article card
- refactor readtime to work the same way
