### PR TITLE
US12825 - Tag Names and Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ _site
 .sass-cache
 .jekyll-metadata
 .env
+.vscode
 collections

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "jekyll", "~> 3.7.2"
 gem "pry"
 gem "dotenv"
+# gem "hubspot-ruby", "~> 0.4.0", path: File.join(File.dirname(__FILE__), "../hubspot-ruby")
 gem "hubspot-ruby", "~> 0.4.0", git: "https://github.com/ample/hubspot-ruby.git"
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/ample/hubspot-ruby.git
-  revision: b50f8db2133ab1ce8278a5addcdc64ec5f0999fc
+  revision: c8078907db1d928671570baccd7aa3ae24e99047
   specs:
-    hubspot-ruby (0.4.0)
+    hubspot-ruby (0.4.1)
       activesupport (>= 3.0.0)
       httparty (>= 0.10.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.5)
+    activesupport (5.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.2)
@@ -36,7 +36,7 @@ GEM
     ffi (1.9.23)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
-    httparty (0.16.1)
+    httparty (0.16.2)
       multi_xml (>= 0.5.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,6 @@ email: info@crossroads.net
 description: No matter what your beliefs, you are welcome here.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://www.crossroads.net" # the base hostname & protocol for your site, e.g. http://example.com
-tag_search_url: "https://int.crossroads.net"
 
 # disable_hubspot: true
 permalink: pretty

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ email: info@crossroads.net
 description: No matter what your beliefs, you are welcome here.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://www.crossroads.net" # the base hostname & protocol for your site, e.g. http://example.com
+tag_search_url: "https://int.crossroads.net"
 
 # disable_hubspot: true
 permalink: pretty

--- a/_config.yml
+++ b/_config.yml
@@ -64,7 +64,7 @@ hubspot:
       featured_image: featured_image
       author: blog_post_author/display_name
       date: publish_date
-      topic: topics
+      topic_names: topic_names
   authors:
     layout: author
     properties:

--- a/_includes/_article-body.html
+++ b/_includes/_article-body.html
@@ -10,8 +10,8 @@
       </div>
       <div class="article_tags">
         <h5 class="control-label">Tags</h5>
-        {% for tag in page.topic %}
-          <span class="article_tag">{{ tag }}</span>
+        {% for tag in page.topic_names %}
+          <a href="{{ site.tag_search_url }}/search?q=tags: '{{ tag }}'" class="article_tag">{{ tag }}</a>
         {% endfor %}
       </div>
     </div>

--- a/_includes/_article-body.html
+++ b/_includes/_article-body.html
@@ -8,12 +8,14 @@
         <h5 class="control-label">Share</h5>
         <div class="addthis_sharing_toolbox"></div>
       </div>
+      {% if page.topic_names.size > 0 %}
       <div class="article_tags">
         <h5 class="control-label">Tags</h5>
         {% for tag in page.topic_names %}
-          <a href="{{ site.tag_search_url }}/search?q=tags: '{{ tag }}'" class="article_tag">{{ tag }}</a>
+          <a href="{{ site.search_domain }}/search?q=tags: '{{ tag }}'" class="article_tag">{{ tag }}</a>
         {% endfor %}
       </div>
+      {% endif %}
     </div>
     <div class="article_body col-md-8 font-size-base" id="scrollDistance" style="line-height: 1.55;">
       {{ page.content | markdownify }}

--- a/_plugins/env_generator.rb
+++ b/_plugins/env_generator.rb
@@ -5,6 +5,7 @@ module Jekyll
     def generate(site)
       @site = site
       @site.config['env'] = ENV['JEKYLL_ENV'] || 'development'
+      @site.config['search_domain'] = ENV['SEARCH_DOMAIN'] || 'https://www.crossroads.net'
       @site.config['shared_header'] = {
         "cms" => "https://#{env_prefix}.crossroads.net/proxy/content/",
         "app" => "https://#{env_prefix}.crossroads.net/",


### PR DESCRIPTION
Add support for tag names which link to int search.

Depends on ample/hubspot-ruby#1.