### PR TITLE
DE5343 Consistent tab names

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,7 +33,7 @@
   <link rel="stylesheet" href="//d1tmclqz61gqwd.cloudfront.net/styles/crds-styles-2.3.0.min.css">
   {% asset application.scss %}
 
-  <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+  <title>{% if page.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
   <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,7 +33,7 @@
   <link rel="stylesheet" href="//d1tmclqz61gqwd.cloudfront.net/styles/crds-styles-2.3.0.min.css">
   {% asset application.scss %}
 
-  <title>{% if page.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}</title>
+  <title>{% if page.title and page.title != site.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
   <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
   <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">

--- a/authors.md
+++ b/authors.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Authors
 ---
 
 <div class="container">

--- a/podcasts.md
+++ b/podcasts.md
@@ -1,27 +1,28 @@
 ---
 layout: default
+title: Podcasts
 ---
 
 <div class="container media-podcast">
   <p class="breadcrumb flush-bottom hard"><a href="{{ site.url }}">Media</a> /</p>
-  <h2 class="section-header landing-header flush-top">Podcasts</h2>
-  <div data-card-deck class="card-deck">
-    <div class="cards-2x">
-      <div class="row">
-      {% for podcast in site.podcasts %}
-        <div class="card">
-          <a href="{{ podcast.url }}">
-            <img class="" src="{{ podcast.image | imgix: site.imgix }}">
-          </a>
-          <div class="card-block hard-bottom">
+    <h2 class="section-header landing-header flush-top">Podcasts</h2>
+    <div data-card-deck class="card-deck">
+      <div class="cards-2x">
+        <div class="row">
+        {% for podcast in site.podcasts %}
+          <div class="card">
             <a href="{{ podcast.url }}">
-              <h4 class="card-title card-title--overlap text-uppercase">{{ podcast.title }}</h4>
+              <img class="" src="{{ podcast.image | imgix: site.imgix }}">
             </a>
-            <p>{{ podcast.content | strip_html | truncatewords: 25 }}</p>
+            <div class="card-block hard-bottom">
+              <a href="{{ podcast.url }}">
+                <h4 class="card-title card-title--overlap text-uppercase">{{ podcast.title }}</h4>
+              </a>
+              <p>{{ podcast.content | strip_html | truncatewords: 25 }}</p>
+            </div>
           </div>
+        {% endfor %}
         </div>
-      {% endfor %}
       </div>
     </div>
   </div>
-</div>

--- a/podcasts.md
+++ b/podcasts.md
@@ -12,7 +12,7 @@ title: Podcasts
         {% for podcast in site.podcasts %}
           <div class="card">
             <a href="{{ podcast.url }}">
-              <img class="" src="{{ podcast.image | imgix: site.imgix }}">
+              <img src="{{ podcast.image | imgix: site.imgix }}">
             </a>
             <div class="card-block hard-bottom">
               <a href="{{ podcast.url }}">


### PR DESCRIPTION
Updates tabs to all be "Page title | Site Title" or to be "Site Title" if a page title doesn't exist.

Also adds a title to the Podcasts landing page