### PR TITLE
DE5426 - Social icon styles

### DIFF
--- a/_assets/stylesheets/_global.scss
+++ b/_assets/stylesheets/_global.scss
@@ -75,3 +75,18 @@ h3 {
 .soft-7-bottom {
   padding-bottom: 7rem;
 }
+
+// Overwrite addthis styles on social icons
+.addthis_default_style {
+  .custom_images {
+    a {
+      font-size: 1.5rem;
+      margin-bottom: 0;
+      padding-top: .25rem;
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Update addthis styles for social icons. They no longer underline on hover and I've made the click area larger for the icons.

No corresponding PRs.