### PR TITLE
Defect/de5485 load more space

### DIFF
--- a/_assets/stylesheets/_utilities.scss
+++ b/_assets/stylesheets/_utilities.scss
@@ -12,6 +12,10 @@
   .cards-2x-sm .card {
     float: left;
     max-width: 50%;
+
+    &:nth-child(odd) {
+      clear: left;
+    }
   }
 }
 

--- a/music.html
+++ b/music.html
@@ -33,34 +33,13 @@ paginate:
       </div>
     </div>
 
-    <div class="card-deck">
-      <div class="cards-2x">
-        <div class="row">
-          {% assign featured = page.songs.offset | slice: 1, 2 %}
-          {% for song in featured %}
-            <div class="card">
-              <a href="{{ song.url }}">
-                <img src="{{ song.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_card }}" sizes="{{ site.image_sizes.cards_2x }}" data-optimize-img>
-              </a>
-              <div class="card-block hard">
-                <a href="{{ song.url }}">
-                  <h5 class="text-gray-dark font-family-base-mid">{{ song.title }}</h5>
-                </a>
-              </div>
-            </div>
-          {% endfor %}
-        </div>
-      </div>
-    </div>
-  {% endif %}
-
-  <div class="card-deck">
-    <div class="cards-4x cards-2x-sm" data-page="songs">
-      <div class="row" data-page-number="{{ page.songs.page }}">
-        {% for song in page.songs.docs %}
+    <div class="cards-2x">
+      <div class="row">
+        {% assign featured = page.songs.offset | slice: 1, 2 %}
+        {% for song in featured %}
           <div class="card">
             <a href="{{ song.url }}">
-              <img src="{{ song.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_card }}" sizes="{{ site.image_sizes.cards_4x }}" data-optimize-img>
+              <img src="{{ song.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_card }}" sizes="{{ site.image_sizes.cards_2x }}" data-optimize-img>
             </a>
             <div class="card-block hard">
               <a href="{{ song.url }}">
@@ -70,12 +49,29 @@ paginate:
           </div>
         {% endfor %}
       </div>
-      <div class="loading hide">
-        {% include _preloader.html %}
-      </div>
     </div>
-    {% include _pagination.html collection="songs" link_root="music" remote=true %}
+  {% endif %}
+
+  <div class="cards-4x cards-2x-sm" data-page="songs">
+    <div class="row" data-page-number="{{ page.songs.page }}">
+      {% for song in page.songs.docs %}
+        <div class="card">
+          <a href="{{ song.url }}">
+            <img src="{{ song.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_card }}" sizes="{{ site.image_sizes.cards_4x }}" data-optimize-img>
+          </a>
+          <div class="card-block hard">
+            <a href="{{ song.url }}">
+              <h5 class="text-gray-dark font-family-base-mid">{{ song.title }}</h5>
+            </a>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+    <div class="loading hide">
+      {% include _preloader.html %}
+    </div>
   </div>
+  {% include _pagination.html collection="songs" link_root="music" remote=true %}
 </div>
 
 


### PR DESCRIPTION
To test, visit `/music/` and see how cards load at various screen widths. I was able to recreate the float defect when loading additional songs on an iPhone X-sized device.

I'm doing two things in this PR. First, I'm adding a `clear: left` to every odd numbered card to address the spacing issue. 

The other thing I did was remove the `.card-deck` wrapping class and accompanying div from the markup. Our `card-deck` class is using flexbox to achieve a "all cards are the same height" thing which isn't needed here. This layout is using both our `card-deck` **and** Bootstrap's grid, and ideally you should use one or the other. Bootstrap 3.7 uses floats for its grid, and floats are the mortal enemy of flexbox. You end up with weird bugs when the two are combined, so it's good rule of thumb to chose one or the other when writing your CSS.

I've tested everything locally on Firefox and Chrome and didn't see any regressions pop up in removing the wrapping `<div>`.

No corresponding PRs.