### PR TITLE
DE5535 - Gingerbread icing

### DIFF
--- a/_assets/stylesheets/_podcast.scss
+++ b/_assets/stylesheets/_podcast.scss
@@ -55,6 +55,13 @@
       }
     }
 
+    @media screen and (max-width: $screen-sm) and (orientation: landscape) {
+      .podcast-header-artwork {
+        height: 200px;
+        width: 200px;
+      }
+    }
+
     @media screen and (min-width: $screen-sm) {
       .podcast-header-text {
         left: 330px;


### PR DESCRIPTION
Problem: When visiting `/podcasts/spirit-stories/` on mobile, if the user changes the orientation of their device from portrait to landscape, the podcast artwork doesn't resize and text will overlap.

Solution: Created a CSS fix to resize the image for podcast artwork when a mobile device changes orientation.

No corresponding PRs.