### PR TITLE
Defect/de5571 placeholder image ghosting

### DIFF
--- a/_assets/javascripts/components/images.js
+++ b/_assets/javascripts/components/images.js
@@ -102,6 +102,8 @@ CRDS.BgImageOptimizer = function(bgEl) {
 CRDS.BgImageOptimizer.prototype.constructor = CRDS.BgImageOptimizer;
 
 CRDS.BgImageOptimizer.prototype.renderTmpImg = function() {
+  this.bgEl.parent().css('position', 'relative');
+
   // First, create a clone of the element with the background image and remove
   // its content. Then place it behind the primary element.
   this.tmpPlacholderBgEl = this.bgEl.clone();

--- a/_assets/stylesheets/_fonts.scss
+++ b/_assets/stylesheets/_fonts.scss
@@ -25,7 +25,7 @@
  *
  * © 2009-2018 Adobe Systems Incorporated. All Rights Reserved.
  */
-/*{"last_published":"2018-03-30 15:35:15 UTC"}*/
+/*{"last_published":"2018-06-27 20:29:35 UTC"}*/
 
 @import url("https://p.typekit.net/p.css?s=1&k=ccb3vpa&ht=tk&f=9805.9806.26053.26056.26058.26059.26062.26065.26067.26016.26018.26024.26044.26045&a=5953047&app=typekit&e=css");
 

--- a/_assets/stylesheets/_jumbocard.scss
+++ b/_assets/stylesheets/_jumbocard.scss
@@ -1,10 +1,35 @@
 .jumbocard {
+  height: 275px;
   position: relative;
-  height: 0;
-  padding-top: 75%; // 4x3
 
-  @media (min-width: $screen-sm) {
-    padding-top: 56.25%; // 16x9
+  @media screen and (min-width: $screen-xs) and (orientation: portrait) {
+    height: 390px;
+  }
+
+  @media screen and (min-width: $screen-sm) and (orientation: portrait) {
+    height: 380px;
+  }
+
+  @media screen and (min-width: $screen-md) and (orientation: portrait) {
+    height: 400px;
+  }
+
+  @media screen and (min-width: $screen-lg) {
+    height: 420px;
+  }
+
+  @media screen and (min-width: $screen-xs) and (orientation: landscape) {
+    height: 300px;
+  }
+
+  @media screen and (min-width: $screen-md) and (orientation: landscape) {
+    height: 400px;
+  }
+
+  &[style*='background-image'] {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
   }
 
   & .jumbocard-link {
@@ -47,12 +72,30 @@
 }
 
 .jumbocard-xl {
-  @media (max-width: $screen-xs) {
-    padding-top: calc(100vh - 62px); // full height minus header height
+  height: calc(100vh - 90px);
+
+  @media screen and (min-width: $screen-xs) and (orientation: portrait) {
+    height: 500px;
   }
 
-  @media (min-width: $screen-md) {
-    padding-top: 40rem; // lock to 640px high
+  @media screen and (min-width: $screen-sm) and (orientation: portrait) {
+    height: 550px;
+  }
+
+  @media screen and (min-width: $screen-md) and (orientation: portrait) {
+    height: 600px;
+  }
+
+  @media screen and (min-width: $screen-lg) {
+    height: 650px;
+  }
+
+  @media screen and (min-width: $screen-xs) and (orientation: landscape) {
+    height: calc(100vh - 80px);
+  }
+
+  @media screen and (min-width: $screen-md) and (orientation: landscape) {
+    height: 600px;
   }
 
   .jumbocard-content {

--- a/_assets/stylesheets/_jumbocard.scss
+++ b/_assets/stylesheets/_jumbocard.scss
@@ -1,29 +1,10 @@
 .jumbocard {
-  height: 275px;
   position: relative;
+  height: 0;
+  padding-top: 75%; // 4x3
 
-  @media screen and (min-width: $screen-xs) and (orientation: portrait) {
-    height: 390px;
-  }
-
-  @media screen and (min-width: $screen-sm) and (orientation: portrait) {
-    height: 380px;
-  }
-
-  @media screen and (min-width: $screen-md) and (orientation: portrait) {
-    height: 400px;
-  }
-
-  @media screen and (min-width: $screen-lg) {
-    height: 420px;
-  }
-
-  @media screen and (min-width: $screen-xs) and (orientation: landscape) {
-    height: 300px;
-  }
-
-  @media screen and (min-width: $screen-md) and (orientation: landscape) {
-    height: 400px;
+  @media (min-width: $screen-sm) {
+    padding-top: 56.25%; // 16x9
   }
 
   &[style*='background-image'] {
@@ -72,30 +53,12 @@
 }
 
 .jumbocard-xl {
-  height: calc(100vh - 90px);
-
-  @media screen and (min-width: $screen-xs) and (orientation: portrait) {
-    height: 500px;
+  @media (max-width: $screen-xs) {
+    padding-top: calc(100vh - 62px); // full height minus header height
   }
 
-  @media screen and (min-width: $screen-sm) and (orientation: portrait) {
-    height: 550px;
-  }
-
-  @media screen and (min-width: $screen-md) and (orientation: portrait) {
-    height: 600px;
-  }
-
-  @media screen and (min-width: $screen-lg) {
-    height: 650px;
-  }
-
-  @media screen and (min-width: $screen-xs) and (orientation: landscape) {
-    height: calc(100vh - 80px);
-  }
-
-  @media screen and (min-width: $screen-md) and (orientation: landscape) {
-    height: 600px;
+  @media (min-width: $screen-md) {
+    padding-top: 40rem; // lock to 640px high
   }
 
   .jumbocard-content {

--- a/_assets/stylesheets/pages/_podcast.scss
+++ b/_assets/stylesheets/pages/_podcast.scss
@@ -185,6 +185,7 @@
       box-shadow: 0 0 .5rem 0 rgba($cr-black, .15);
       flex: 0 0 80px;
       margin-left: 2rem;
+      z-index: 10;
 
       > img {
         width: 100%;

--- a/_includes/_jumbocard.html
+++ b/_includes/_jumbocard.html
@@ -1,7 +1,7 @@
 {% if include.size == "xl" %}
-  <div class="jumbocard jumbocard-xl" style="background-image: url('{{ jumbocard.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}'); background-size: cover; background-position: center center;" data-optimize-bg-img>
+  <div class="jumbocard jumbocard-xl" style="background-image: url('{{ jumbocard.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}');" data-optimize-bg-img>
 {% else %}
-  <div class="jumbocard" style="background-image: url('{{ jumbocard.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}'); background-size: cover;" data-optimize-bg-img>
+  <div class="jumbocard" style="background-image: url('{{ jumbocard.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}');" data-optimize-bg-img>
 {% endif %}
   <a class="jumbocard-link" href="{{ jumbocard.url }}">
     {% include _media-label.html source=jumbocard %}


### PR DESCRIPTION
### Problem

Images in featured media section of media homepage "jump" on load. Also found that the placeholder background image repeated itself when it shouldn't.

Bonus problem: Image on the podcast episode header "flashed" while loading. 

### Solution

I removed the inline styles for the background images. Because these new jumbocards were essentially behaving like jumbotrons, I added our jumbotron background style rules to its CSS. This prevented the repeating imagery and cleaned up the markup considerably.

I also removed the padding solution from the jumbocard styles. Using padding to set the height was breaking our Imigix solution, which relies on a explicit height of it's parent to resize itself appropriately. To fix this, I added a series of image heights at various breakpoints and screen orientations.

Bonus solution: I increased the `z-index` of the podcast header image and now it doesn't flash when loading.

No corresponding PRs.