### PR TITLE
Defect/de5581 message details breadcrumbs

### DIFF
--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -57,6 +57,11 @@ layout: default
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
 
+        <!-- This line of code changed the association of messages to Series.
+          It's now adding videos to the Series pages and breaking the video template
+          Defects are being filed on DEMO and INT -->
+
+        <!-- Original code: {% assign messages = site.messages | where: "series", page.title | reverse %} -->
         {% assign messages = page.associations['videos'] %}
 
         {% if messages.size > 1 %}

--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -35,7 +35,7 @@ layout: default
             </h1>
             <hr class="hero">
 
-            <div class="font-size-base markdown">{{ page.content }}</div>
+            <div class="font-size-base">{{ page.content }}</div>
 
             <ul class="list-inline soft-half-top">
               <li>
@@ -56,12 +56,6 @@ layout: default
   <div class="container">
     <div class="row">
       <div class="col-sm-10 col-sm-offset-1">
-
-        <!-- This line of code changed the association of messages to Series.
-          It's now adding videos to the Series pages and breaking the video template
-          Defects are being filed on DEMO and INT -->
-
-        <!-- Original code: {% assign messages = site.messages | where: "series", page.title | reverse %} -->
         {% assign messages = page.associations['videos'] %}
 
         {% if messages.size > 1 %}

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -17,15 +17,24 @@ layout: default
       </div>
       {% endif %}
 
+      <!-- Start breadcrumbs -->
+      {% assign url_array = page.url | split: '/' | shift | pop %}
+      {% capture url_string %} {{ page.url | replace: '/', " " }}{% endcapture %}
+      {% assign url="" %}
       <ol class="breadcrumb push-top hard-sides flush-bottom hard-sides">
         <li><a href="/">Media</a></li>
-        {% if series %}
-        <li><a href="/series">Series</a></li>
-        <li><a href="{{ series.url }}">{{ series.title }}</a></li>
-        {% else %}
-        <li><a href="/videos">Videos</a></li>
-        {% endif %}
+
+        {% for breadcrumb in url_array %}
+        {% capture first_word %}{{ url_string | truncatewords: 1, "" }}{% endcapture %}
+        {% capture url %}{{ url }}/{{ first_word }}{% endcapture %}
+
+        <li><a href="{{ url }}">{{ breadcrumb | replace: '-', ' ' | capitalize }}</a></li>
+
+        {% capture url_string %}{{ url_string | remove_first: first_word }}{% endcapture %}
+        {% endfor %}
       </ol>
+      <!-- End breadcrumbs -->
+
       <h1 class="font-family-condensed-extra text-uppercase flush-top push-bottom">{{ page.title }}</h1>
       <!-- Nav tabs -->
       <ul class="nav nav-tabs" role="tablist">


### PR DESCRIPTION
### Problem
Breadcrumbs on videos and messages navigated to from a series landing page all defaulted to `media / video`. Breadcrumbs should have a similar structure as the url - so if it's a video it would be `media / video` and if it's a message associated with a series, it would be `media / series / series name`

### Solution
Create a dynamic solution for rendering breadcrumbs from the page's url. Rather than fill the page up with a bunch of if/else/for statements. 

No corresponding PRs.