### PR TITLE
Defect/de5582 series name style

### DIFF
--- a/_assets/stylesheets/_cards.scss
+++ b/_assets/stylesheets/_cards.scss
@@ -43,3 +43,19 @@
   position: relative;
   z-index: 1;
 }
+
+.card {
+  > a {
+    color: $cr-gray-dark;
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    .card-block {
+      .card-title:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/_includes/_message-card.html
+++ b/_includes/_message-card.html
@@ -7,11 +7,11 @@
 <div class="card">
   <a href="{{ message.url }}" title="{{ message.title }}">
     <img src="{{ image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{{ site.image_sizes.cards_2x }}" alt="{{ message.title }}" data-optimize-img>
+    <div class="card-block hard">
+      <h3 class="card-title font-size-small font-family-condensed push-half-top push-quarter-bottom">
+        {{ message.title }}
+      </h3>
+      <p class="font-family-base font-size-smaller text-gray-light">{{ page.title }}</p>
+    </div>
   </a>
-  <div class="card-block hard">
-    <h3 class="font-size-small font-family-condensed push-half-top push-quarter-bottom">
-      <a href="{{ message.url }}">{{ message.title }}</a>
-    </h3>
-    <p class="font-family-base font-size-smaller text-gray-light">{{ page.title }}</p>
-  </div>
 </div>

--- a/_includes/_message-card.html
+++ b/_includes/_message-card.html
@@ -9,10 +9,9 @@
     <img src="{{ image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{{ site.image_sizes.cards_2x }}" alt="{{ message.title }}" data-optimize-img>
   </a>
   <div class="card-block hard">
-    <a href="{{ message.url }}">
-      <h5 class="card-title flush-bottom" >{{ message.title }}</h5>
-      <h5 class="card-title flush-bottom" >{{ page.title }}</h5>
-    </a>
-    <p class="font-family-base font-size-smaller text-gray-light">{{ message.series }}</p>
+    <h3 class="font-size-small font-family-condensed push-half-top push-quarter-bottom">
+      <a href="{{ message.url }}">{{ message.title }}</a>
+    </h3>
+    <p class="font-family-base font-size-smaller text-gray-light">{{ page.title }}</p>
   </div>
 </div>


### PR DESCRIPTION
### Problem
When navigating to a Series landing page, the headings for the messages linked at the bottom are incorrect. They should match the designs [here](https://projects.invisionapp.com/share/WRGQZ5E4N3A#/screens/291615854).

### Solution
Refactored code and added correct styles to the markup. Minimal local styles required to override default DDK link behaviour. DDK links are much lighter in color and underline on hover - because the entire card is a link this isn't desired behaviour.