### PR TITLE
DE5599 - Album art

### DIFF
--- a/_assets/stylesheets/pages/_songs.scss
+++ b/_assets/stylesheets/pages/_songs.scss
@@ -17,3 +17,12 @@
     width: 100%;
   }
 }
+
+.media-music-album {
+  .album-artwork {
+    box-shadow: 0 0 .5rem 0 rgba($cr-black, .15);
+    margin: 0 auto;
+    max-width: 360px;
+    width: 100%;
+  }
+}

--- a/_layouts/album.html
+++ b/_layouts/album.html
@@ -10,7 +10,9 @@ layout: default
         <div class="row">
           <div class="col-sm-8 col-sm-offset-2 text-left md-text-center">
             <!-- album image -->
-            <img class="center-block" src="{{ page.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}" sizes="{{ site.image_sizes.music_thumb }}" data-optimize-img>
+            <div class="album-artwork">
+              <img class="img-full-width" src="{{ page.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}" sizes="{{ site.image_sizes.song_artwork }}" data-optimize-img>
+            </div>
 
             <!-- breadcrumb navigation -->
             <ol class="breadcrumb hard-sides hard-bottom push-top flush-bottom">


### PR DESCRIPTION
### Problem

Artwork on `/albums/whatever-pleases-you` bounces around the page before loading.

![album-bounce](https://user-images.githubusercontent.com/5159392/42389557-1fa60ab2-8117-11e8-947a-e426bd063df3.gif)


### Solution

Refactor album landing page, setting and image width and adding a width, max-width and margin to newly created wrapping div. Also added a box-shadow as the design indicated.