### PR TITLE
DE5582 - Video nav z-index

### DIFF
--- a/_assets/stylesheets/_sidebar-navigation.scss
+++ b/_assets/stylesheets/_sidebar-navigation.scss
@@ -5,6 +5,7 @@
 
   .dropdown {
     display: block;
+    z-index: 1;
   }
 
   .dropdown-menu {


### PR DESCRIPTION
### Problem

When opening the shared header, the side nav on /videos appeared on top of the shared header.

### Solution

Adjust z-index to sit beneath the shared header. I tested this solution locally on desktop and mobile -sized screens and it seems to have fixed the problem.