### PR TITLE
US13768: Update Music Landing

### DIFF
--- a/_assets/stylesheets/_jumbocard.scss
+++ b/_assets/stylesheets/_jumbocard.scss
@@ -91,6 +91,7 @@
     }
 
     .jumbocard-title {
+      line-height: .91;
       @media (min-width: $screen-sm) {
         font-size: 90px;
         line-height: .89;

--- a/_assets/stylesheets/_jumbocard.scss
+++ b/_assets/stylesheets/_jumbocard.scss
@@ -76,13 +76,25 @@
   }
 }
 
-.jumbocard-music {
+.music-tpl .jumbocard {
   @media (min-width: $screen-sm) {
     padding-top: 40rem; // 640px
   }
 
   @media (min-width: $screen-md) {
     padding-top: 56.25rem; // 900px
+  }
+
+  .breadcrumb {
+    position: absolute;
+    top: 60px;
+    left: 15px;
+    z-index: 1;
+
+    @media (min-width: $screen-sm) {
+      left: 60px;
+    }
+
   }
 
   .jumbocard-content {

--- a/_assets/stylesheets/_jumbocard.scss
+++ b/_assets/stylesheets/_jumbocard.scss
@@ -39,6 +39,10 @@
       padding: 30px;
     }
 
+    &.gradient-bg {
+      background: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,.7));
+    }
+
     .jumbocard-title {
       font-size: 40px;
       line-height: .75;

--- a/_assets/stylesheets/_jumbocard.scss
+++ b/_assets/stylesheets/_jumbocard.scss
@@ -13,7 +13,7 @@
     background-repeat: no-repeat;
   }
 
-  & .jumbocard-link {
+  .jumbocard-link {
     position: absolute;
     top: 0;
     right: 0;
@@ -29,12 +29,11 @@
     }
   }
 
-  & .jumbocard-content {
+  .jumbocard-content {
     position: absolute;
     bottom: 0;
     width: 100%;
     padding: 15px;
-    background: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,.7));
 
     @media (min-width: $screen-sm) {
       padding: 30px;
@@ -72,6 +71,29 @@
       @media (min-width: $screen-sm) {
         font-size: 110px;
         padding-bottom: $line-height-computed/2;
+      }
+    }
+  }
+}
+
+.jumbocard-music {
+  @media (min-width: $screen-sm) {
+    padding-top: 40rem; // 640px
+  }
+
+  @media (min-width: $screen-md) {
+    padding-top: 56.25rem; // 900px
+  }
+
+  .jumbocard-content {
+    @media (max-width: $screen-sm) {
+      padding-bottom: 2.8125rem; // 45px
+    }
+
+    .jumbocard-title {
+      @media (min-width: $screen-sm) {
+        font-size: 90px;
+        line-height: .89;
       }
     }
   }

--- a/_config.yml
+++ b/_config.yml
@@ -174,7 +174,7 @@ contentful:
           topic_slug: category/slug
           tags: tags/title
           author: author/full_name
-          audio_duration: audio_duration
+          duration: audio_duration
           album_title: album/title
           album_image: album/image/url
           album_slug: album/slug

--- a/_config.yml
+++ b/_config.yml
@@ -186,6 +186,9 @@ contentful:
           google_play_url: google_play_url
           youtube_url: youtube_url
           related_videos: related_videos
+          call_to_action: call_to_action
+          featured_label: featured_label
+          featured_text: featured_text
           slug: slug
         other:
           layout: song

--- a/_config.yml
+++ b/_config.yml
@@ -188,7 +188,7 @@ contentful:
           related_videos: related_videos
           call_to_action: call_to_action
           featured_label: featured_label
-          featured_text: featured_text
+          featured_subtitle: featured_subtitle
           slug: slug
         other:
           layout: song

--- a/_includes/_media-card.html
+++ b/_includes/_media-card.html
@@ -9,6 +9,8 @@
   <a class="relative" href="{{ card.url }}">
     {% if card.content_type != nil %}
       {% include _media-label.html source=card %}
+    {% else %}
+      {% include _media-label.html source=card content_type=include.content_type %}
     {% endif %}
     <img src="{{ card.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{{ site.image_sizes.cards_2x }}" data-optimize-img>
   </a>

--- a/_includes/_media-card.html
+++ b/_includes/_media-card.html
@@ -7,7 +7,9 @@
 <div class="card">
 {% endif %}
   <a class="relative" href="{{ card.url }}">
-    {% include _media-label.html source=card %}
+    {% if card.content_type != nil %}
+      {% include _media-label.html source=card %}
+    {% endif %}
     <img src="{{ card.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{{ site.image_sizes.cards_2x }}" data-optimize-img>
   </a>
   <div class="card-block hard soft-quarter-top">
@@ -16,7 +18,13 @@
       <a href="{{ card.url }}">{{ card.title }}</a>
     </h3>
     <p class="card-text soft-quarter-top">
-      <a class="text-gray-light font-size-smaller" href="{{ author.url }}">{{ author.name | titleize }}</a>
+      {% for person in card.author %}
+        {% assign author = site.authors | where: "name", person | first %}
+          <a class="text-gray-light font-size-smaller" href="{{ author.url }}">{{ person }}</a>
+        {% unless forloop.last %}
+          <span class="text-gray-light">&amp;</span>
+        {% endunless %}
+      {% endfor %}
     </p>
   </div>
 </div>

--- a/_includes/_media-label.html
+++ b/_includes/_media-label.html
@@ -11,7 +11,7 @@
   <svg class="icon" viewBox="0 0 256 256">
     {% if include.source.content_type == "article" %}
       <use xlink:href="/assets/svgs/icons.svg#media-article"></use>
-    {% elsif include.source.content_type == "video" or include.source.content_type == "song" %}
+    {% elsif include.source.content_type == "video" or include.source.content_type == "song" or include.content_type == "song" %}
       <use xlink:href="/assets/svgs/icons.svg#media-video"></use>
     {% elsif include.source.content_type == "podcast" or include.source.content_type == "episode" %}
       <use xlink:href="/assets/svgs/icons.svg#media-podcast"></use>

--- a/_includes/_media-label.html
+++ b/_includes/_media-label.html
@@ -11,7 +11,7 @@
   <svg class="icon" viewBox="0 0 256 256">
     {% if include.source.content_type == "article" %}
       <use xlink:href="/assets/svgs/icons.svg#media-article"></use>
-    {% elsif include.source.content_type == "video" %}
+    {% elsif include.source.content_type == "video" or include.source.content_type == "song" %}
       <use xlink:href="/assets/svgs/icons.svg#media-video"></use>
     {% elsif include.source.content_type == "podcast" or include.source.content_type == "episode" %}
       <use xlink:href="/assets/svgs/icons.svg#media-podcast"></use>

--- a/music.html
+++ b/music.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Music
+permalink: /new-music/
 worship_training_headline: Be Part of This
 worship_training_copy: Worship Training helps you grow musical or technical
                         giftings so you can serve the community.
@@ -8,62 +9,48 @@ worship_training_cta: Learn More
 worship_training_img: //crds-cms-uploads.imgix.net/content/images/crossroads-worship-training-music.jpg
 paginate:
   songs:
-    offset: 3
+    offset: 4
     per: 8
     sort: date desc
 ---
 
-<div class="container push-bottom">
-  <ol class="breadcrumb hard-sides hard-bottom push-top flush-bottom">
-    <li><a href="/">Media</a></li>
-  </ol>
+  <div class="push-bottom">
+    {% if page.songs.page == 1 %}
+      {% assign featured = page.songs.offset %}
+      {% for jumbocard in featured %}
+        <div class="jumbocard jumbocard-music jumbocard-xl" style="background-image: url('{{ jumbocard.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}');" data-optimize-bg-img>
+          <a class="jumbocard-link" href="{{ jumbocard.url }}"></a>
+          <div class="jumbocard-content text-left push-right">
+            <p class="font-size-smaller text-uppercase text-gray-lighter push-half-bottom">{{ jumbocard.featured_label }}</p>
+            <h2 class="jumbocard-title font-family-condensed-extra text-uppercase text-white flush">{{ jumbocard.title }}</h2>
+            <p class="text-white font-size-base push-half-top">{{ jumbocard.featured_text }}</p>
+            <a href="{{ jumbocard.url }}" class="btn btn-white btn-outline">{{ jumbocard.call_to_action }}</a>
+          </div>
+        </div>
 
-  <h1 class="font-family-condensed-extra text-uppercase flush-top push-bottom">Music</h1>
-
-  {% if page.songs.page == 1 %}
-    {% assign hero = page.songs.offset | first %}
-    {% if hero.bg_image %}
-      {% assign bg_img = hero.bg_image %}
-    {% else %}
-      {% assign bg_img = hero.image %}
+      {% endfor %}
+      {% if hero.bg_image %}
+        {% assign bg_img = hero.bg_image %}
+      {% else %}
+        {% assign bg_img = hero.image %}
+      {% endif %}
     {% endif %}
-    <div class="jumbotron jumbotron-xl" style="background-image: url('{{ bg_img | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')" data-optimize-bg-img>
-      <div class="bg-overlay"></div>
-      <div class="jumbotron-content">
-        <h4 class="font-size-small text-uppercase text-gray-lighter">
-          Newest Song
-        </h4>
-        <h1 class="section-header flush-top push-quarter-bottom">{{ hero.title }}</h1>
-        <h6 class="font-size-base text-gray-lighter">
-          {{ hero.content }}
-        </h6>
-        <a class="btn btn-lg btn-white btn-outline" href="{{ hero.url }}">Rock Out</a>
-      </div>
-    </div>
+  </div>
 
-    <div class="cards-2x">
-      <div class="row">
-        {% assign featured = page.songs.offset | slice: 1, 2 %}
-        {% for song in featured %}
-         {% include _song-card.html imgix_size="2x" %}
+  <div class="container push-bottom">
+    <div class="cards-4x cards-2x-xs" data-page="songs">
+      <div class="row" data-page-number="{{ page.songs.page }}">
+        {% for song in page.songs.docs %}
+          {% include _song-card.html %}
         {% endfor %}
       </div>
+      <div class="loading hide">
+        {% include _preloader.html %}
+      </div>
     </div>
-  {% endif %}
-
-  <div class="cards-4x cards-2x-xs" data-page="songs">
-    <div class="row" data-page-number="{{ page.songs.page }}">
-      {% for song in page.songs.docs %}
-        {% include _song-card.html %}
-      {% endfor %}
-    </div>
-    <div class="loading hide">
-      {% include _preloader.html %}
-    </div>
+    {% include _pagination.html collection="songs" link_root="music" remote=true %}
   </div>
-  {% include _pagination.html collection="songs" link_root="music" remote=true %}
 </div>
-
 
 <div class="container-fluid bg-gray soft">
   <div class="container push-top">

--- a/music.html
+++ b/music.html
@@ -17,16 +17,23 @@ paginate:
 <div class="music-tpl">
   <div class="push-bottom">
     {% if page.songs.page == 1 %}
+      {% assign has_gradient_bg = false %}
       {% assign featured = page.songs.offset %}
       {% for jumbocard in featured %}
-        <div class="jumbocard jumbocard-xl" style="background-image: url('{{ jumbocard.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}');" data-optimize-bg-img>
+        {% if jumbocard.bg_image %}
+          {% assign bg_img = jumbocard.bg_image %}
+        {% else %}
+          {% assign bg_img = jumbocard.image %}
+          {% assign has_gradient_bg = true %}
+        {% endif %}
+        <div class="jumbocard jumbocard-xl" style="background-image: url('{{ bg_img | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}');" data-optimize-bg-img>
           {% if forloop.index == 1 %}
-          <ol class="breadcrumb hard flush-bottom text-white">
-            <li><a href="/">Media</a></li>
-          </ol>
+            <ol class="breadcrumb hard flush-bottom text-white">
+              <li><a href="/">Media</a></li>
+            </ol>
           {% endif %}
           <a class="jumbocard-link" href="{{ jumbocard.url }}"></a>
-          <div class="jumbocard-content text-left push-right">
+          <div class="jumbocard-content {% if has_gradient_bg == true %} gradient-bg {% endif %} text-left push-right">
             <p class="font-size-smaller text-uppercase text-gray-lighter push-half-bottom">{{ jumbocard.featured_label }}</p>
             <h2 class="jumbocard-title font-family-condensed-extra text-uppercase text-white flush">{{ jumbocard.title }}</h2>
             <p class="text-white font-size-base push-half-top">{{ jumbocard.featured_text }}</p>
@@ -35,13 +42,7 @@ paginate:
             </a>
           </div>
         </div>
-
       {% endfor %}
-      {% if hero.bg_image %}
-        {% assign bg_img = hero.bg_image %}
-      {% else %}
-        {% assign bg_img = hero.image %}
-      {% endif %}
     {% endif %}
   </div>
 

--- a/music.html
+++ b/music.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Music
-permalink: /new-music/
 worship_training_headline: Be Part of This
 worship_training_copy: Worship Training helps you grow musical or technical
                         giftings so you can serve the community.

--- a/music.html
+++ b/music.html
@@ -50,7 +50,7 @@ paginate:
     <div class="cards-4x cards-2x-xs" data-page="songs">
       <div class="row push-top" data-page-number="{{ page.songs.page }}">
         {% for card in page.songs.docs %}
-          {% include _media-card.html %}
+          {% include _media-card.html content_type="song" %}
         {% endfor %}
       </div>
       <div class="loading hide">

--- a/music.html
+++ b/music.html
@@ -6,6 +6,7 @@ worship_training_copy: Worship Training helps you grow musical or technical
                         giftings so you can serve the community.
 worship_training_cta: Learn More
 worship_training_img: //crds-cms-uploads.imgix.net/content/images/crossroads-worship-training-music.jpg
+default_cta: Check It Out
 paginate:
   songs:
     offset: 4
@@ -13,17 +14,25 @@ paginate:
     sort: date desc
 ---
 
+<div class="music-tpl">
   <div class="push-bottom">
     {% if page.songs.page == 1 %}
       {% assign featured = page.songs.offset %}
       {% for jumbocard in featured %}
-        <div class="jumbocard jumbocard-music jumbocard-xl" style="background-image: url('{{ jumbocard.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}');" data-optimize-bg-img>
+        <div class="jumbocard jumbocard-xl" style="background-image: url('{{ jumbocard.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}');" data-optimize-bg-img>
+          {% if forloop.index == 1 %}
+          <ol class="breadcrumb hard flush-bottom text-white">
+            <li><a href="/">Media</a></li>
+          </ol>
+          {% endif %}
           <a class="jumbocard-link" href="{{ jumbocard.url }}"></a>
           <div class="jumbocard-content text-left push-right">
             <p class="font-size-smaller text-uppercase text-gray-lighter push-half-bottom">{{ jumbocard.featured_label }}</p>
             <h2 class="jumbocard-title font-family-condensed-extra text-uppercase text-white flush">{{ jumbocard.title }}</h2>
             <p class="text-white font-size-base push-half-top">{{ jumbocard.featured_text }}</p>
-            <a href="{{ jumbocard.url }}" class="btn btn-white btn-outline">{{ jumbocard.call_to_action }}</a>
+            <a href="{{ jumbocard.url }}" class="btn btn-white btn-outline">
+              {% if jumbocard.call_to_action %} {{ jumbocard.call_to_action }} {% else %} {{ page.default_cta }} {% endif %}
+            </a>
           </div>
         </div>
 
@@ -49,26 +58,26 @@ paginate:
     </div>
     {% include _pagination.html collection="songs" link_root="music" remote=true %}
   </div>
-</div>
 
-<div class="container-fluid bg-gray soft">
-  <div class="container push-top">
-    <div class="jumbotron col-md-6" style="background-image: url('{{ page.worship_training_img | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')" data-optimize-bg-img>
-      <h2 class="section-header push-top push-quarter-bottom text-white">{{ page.worship_training_headline }}</h2>
-      <span class="font-size-base font-family-base-light text-gray-lighter push-bottom block">{{ page.worship_training_copy }}</span>
-      <a class="btn btn-white btn-lg btn-outline font-family-base-light" href="https://www.crossroads.net/worshiptraining">{{ page.worship_training_cta }}</a>
-    </div>
-    <div class="jumbotron bg-charcoal col-md-6">
-      <div class="d-flex flex-column align-items-center justify-content-center">
-        <svg class="icon icon-2 text-white" viewbox="0 0 256 256">
-          <use xlink:href="/assets/svgs/icons.svg#instagram-2"></use>
-        </svg>
-        <svg class="text-white push-top" viewbox="0 0 256 80" width="60%">
-          <use xlink:href="/assets/svgs/icons.svg#crds-music"></use>
-        </svg>
+  <div class="container-fluid bg-gray soft">
+    <div class="container push-top">
+      <div class="jumbotron col-md-6" style="background-image: url('{{ page.worship_training_img | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')" data-optimize-bg-img>
+        <h2 class="section-header push-top push-quarter-bottom text-white">{{ page.worship_training_headline }}</h2>
+        <span class="font-size-base font-family-base-light text-gray-lighter push-bottom block">{{ page.worship_training_copy }}</span>
+        <a class="btn btn-white btn-lg btn-outline font-family-base-light" href="https://www.crossroads.net/worshiptraining">{{ page.worship_training_cta }}</a>
       </div>
-      <h2 class="section-header flush-top push-quarter-bottom hidden">Crossroads Music</h2>
-      <a class="btn btn-white btn-lg btn-outline font-family-base-light" href="https://www.instagram.com/crdsmusic/">Follow us on Instagram</a>
+      <div class="jumbotron bg-charcoal col-md-6">
+        <div class="d-flex flex-column align-items-center justify-content-center">
+          <svg class="icon icon-2 text-white" viewbox="0 0 256 256">
+            <use xlink:href="/assets/svgs/icons.svg#instagram-2"></use>
+          </svg>
+          <svg class="text-white push-top" viewbox="0 0 256 80" width="60%">
+            <use xlink:href="/assets/svgs/icons.svg#crds-music"></use>
+          </svg>
+        </div>
+        <h2 class="section-header flush-top push-quarter-bottom hidden">Crossroads Music</h2>
+        <a class="btn btn-white btn-lg btn-outline font-family-base-light" href="https://www.instagram.com/crdsmusic/">Follow us on Instagram</a>
+      </div>
     </div>
   </div>
 </div>

--- a/music.html
+++ b/music.html
@@ -47,9 +47,9 @@ paginate:
 
   <div class="container push-bottom">
     <div class="cards-4x cards-2x-xs" data-page="songs">
-      <div class="row" data-page-number="{{ page.songs.page }}">
-        {% for song in page.songs.docs %}
-          {% include _song-card.html %}
+      <div class="row push-top" data-page-number="{{ page.songs.page }}">
+        {% for card in page.songs.docs %}
+          {% include _media-card.html %}
         {% endfor %}
       </div>
       <div class="loading hide">


### PR DESCRIPTION
Updated music landing with now with 10000% moar `jumbocards`. Took the approach of limiting banner treatment to the 4 most recent songs. Everything else appears as a song card and uses the load more behavior.

_As per BMiller: gradient background have been removed._

[Related PR](https://github.com/crdschurch/crds-contentful-migrations/pull/9) to set up content model changes