### PR TITLE
Update content tab to read 'Description'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -137,6 +137,7 @@ contentful:
           slug: slug
           topic: category/title
           tags: tags/title
+          description: description
           show_notes: show_notes
           transcription: transcription
           audio_duration: audio_duration
@@ -209,6 +210,7 @@ contentful:
           topic: category/title
           topic_slug: category/slug
           tags: tags/title
+          description: description
           transcription: transcription
           apple_podcasts_url: apple_podcasts_url
           google_play_url: google_play_url
@@ -260,6 +262,7 @@ contentful:
           topic: category/title
           topic_slug: category/slug
           tags: tags/title
+          description: description
           transcription: transcription
           apple_podcasts_url: apple_podcasts_url
           google_play_url: google_play_url

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -37,8 +37,8 @@ layout: default
 
         <h2 class="component-header mobile-push-half-top">This episode</h2>
 
-        {% assign tabs = 'content show_notes transcription' | split: ' ' %}
-        {% if page.show_notes or page.transcription or page.content != blank %}
+        {% assign tabs = 'description show_notes transcription' | split: ' ' %}
+        {% if page.show_notes or page.transcription or page.description %}
           {% include _tabs.html tabs=tabs %}
         {% endif %}
 

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -59,8 +59,8 @@ layout: default
   <div class="container">
     <div class="row push-ends">
       <div class="col-sm-4 col-md-5 col-sm-offset-2">
-        {% assign tabs = 'content transcription' | split: ' ' %}
-        {% if page.transcription or page.content != blank %}
+        {% assign tabs = 'description transcription' | split: ' ' %}
+        {% if page.transcription or page.description %}
           {% include _tabs.html tabs=tabs %}
         {% endif %}
 


### PR DESCRIPTION
### Problem
`page.content` was changing the tab name to "Content"

### Solution
Update the config file to use `description` in the frontmatter and change the logic surrounding the tabs include.