### PR TITLE
Remove related videos from Youtube embeds.

### DIFF
--- a/_includes/_yt-embed.html
+++ b/_includes/_yt-embed.html
@@ -1,4 +1,4 @@
 <div class="embed-responsive embed-responsive-16by9">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ video_id }}" frameborder="0" allow="autoplay; encrypted-media"
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ video_id }}?rel=0" frameborder="0" allow="autoplay; encrypted-media"
     allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
### Problem
When you pause any Youtube embedded video, a list of related videos appears on-screen.

### Solution
Remove the related videos by appending `?rel=0` to the video url.