### PR TITLE
Defect/de5678 related video images

### DIFF
--- a/_includes/_video-card.html
+++ b/_includes/_video-card.html
@@ -6,7 +6,6 @@
 {% endif %}
 
 <div class="card">
-    <p>{{ video.date | date: '%B %d, %Y' }}</p>
   <a class="relative block" href="{{ video.url }}">
     {% if include.imgix_size == "1x" %}
       <img src="{{ image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{{ site.image_sizes.card_1x }}" alt="{{ video.title }}" data-optimize-img>

--- a/_includes/_video-card.html
+++ b/_includes/_video-card.html
@@ -6,6 +6,7 @@
 {% endif %}
 
 <div class="card">
+    <p>{{ video.date | date: '%B %d, %Y' }}</p>
   <a class="relative block" href="{{ video.url }}">
     {% if include.imgix_size == "1x" %}
       <img src="{{ image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{{ site.image_sizes.card_1x }}" alt="{{ video.title }}" data-optimize-img>

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -70,7 +70,7 @@ layout: default
         {% if forloop.first %}<p class="flush-bottom">Featuring {% endif %}
           <a href="{{ author.url }}">{{ author.name | titleize }}</a> {% if forloop.last == false %} and {% endif %} {% if forloop.last %}</p>{% endif%}
           {% endif %}
-          {% endfor%}
+          {% endfor%}https://www.youtube.com/watch?v=8VkZ8YLO5CE
           <p>{{ page.date | format_date }} {% if page.video_duration != nil %}
             <span class="divider push-quarter-sides">•</span> {{ page.video_duration }} {% endif %}</p>
 
@@ -137,23 +137,22 @@ layout: default
 
           {% else %}
 
-          <div class="card-deck carousel" data-crds-carousel="mobile-scroll">
-            <div class="feature-cards">
-              {% if page.topic %}
+          <div class="cards-3x cards-2x-xs">
+            <div class="row">
+            {% if page.topic %}
               {% assign limited = site.videos | where: 'topic', page.topic | sort: 'date' | reverse | exclude: page.title %}
               {% if limited.size < 1 %}
+                {% assign limited = site.videos | sort: 'date' | reverse | slice: 0, 9 | exclude: page.title %}
+              {% endif %}
+            {% else %}
               {% assign limited = site.videos | sort: 'date' | reverse | slice: 0, 9 | exclude: page.title %}
-              {% endif %}
-              {% else %}
-              {% assign limited = site.videos | sort: 'date' | reverse | slice: 0, 9 |exclude: page.title %}
-              {% endif %}
+            {% endif %}
 
-              {% for video in limited limit: 8 %}
+            {% for video in limited limit: 8 %}
               {% include _video-card.html %}
-              {% endfor %}
+            {% endfor %}
             </div>
           </div>
-
           {% endif %}
         </section>
 

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -70,7 +70,7 @@ layout: default
         {% if forloop.first %}<p class="flush-bottom">Featuring {% endif %}
           <a href="{{ author.url }}">{{ author.name | titleize }}</a> {% if forloop.last == false %} and {% endif %} {% if forloop.last %}</p>{% endif%}
           {% endif %}
-          {% endfor%}https://www.youtube.com/watch?v=8VkZ8YLO5CE
+          {% endfor%}
           <p>{{ page.date | format_date }} {% if page.video_duration != nil %}
             <span class="divider push-quarter-sides">•</span> {{ page.video_duration }} {% endif %}</p>
 

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -140,12 +140,12 @@ layout: default
           <div class="cards-3x cards-2x-xs">
             <div class="row">
             {% if page.topic %}
-              {% assign limited = site.videos | where: 'topic', page.topic | reverse | exclude: page.title %}
+              {% assign limited = site.videos | where: 'topic', page.topic | reverse | exclude: page.title | slice: 0, 9 %}
               {% if limited.size < 1 %}
-                {% assign limited = site.videos | reverse | slice: 0, 9 | exclude: page.title %}
+                {% assign limited = site.videos | reverse | exclude: page.title | slice: 0, 9 %}
               {% endif %}
             {% else %}
-              {% assign limited = site.videos | reverse | slice: 0, 9 | exclude: page.title %}
+              {% assign limited = site.videos | reverse | exclude: page.title | slice: 0, 9 %}
             {% endif %}
 
             {% for video in limited limit: 9 %}

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -141,7 +141,7 @@ layout: default
             <div class="row">
             {% if page.topic %}
               {% assign limited = site.videos | where: 'topic', page.topic | reverse | exclude: page.title | slice: 0, 9 %}
-              {% if limited.size < 1 %}
+              {% if limited.size == 0 %}
                 {% assign limited = site.videos | reverse | exclude: page.title | slice: 0, 9 %}
               {% endif %}
             {% else %}

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -140,15 +140,15 @@ layout: default
           <div class="cards-3x cards-2x-xs">
             <div class="row">
             {% if page.topic %}
-              {% assign limited = site.videos | where: 'topic', page.topic | sort: 'date' | reverse | exclude: page.title %}
+              {% assign limited = site.videos | where: 'topic', page.topic | reverse | exclude: page.title %}
               {% if limited.size < 1 %}
-                {% assign limited = site.videos | sort: 'date' | reverse | slice: 0, 9 | exclude: page.title %}
+                {% assign limited = site.videos | reverse | slice: 0, 9 | exclude: page.title %}
               {% endif %}
             {% else %}
-              {% assign limited = site.videos | sort: 'date' | reverse | slice: 0, 9 | exclude: page.title %}
+              {% assign limited = site.videos | reverse | slice: 0, 9 | exclude: page.title %}
             {% endif %}
 
-            {% for video in limited limit: 8 %}
+            {% for video in limited limit: 9 %}
               {% include _video-card.html %}
             {% endfor %}
             </div>


### PR DESCRIPTION
### Problem
Recent/related video images aren't sizing appropriately on load. Also confirmed with Becky that these videos are not supposed to be carousel images on mobile.

### Solution
Change markup to traditional card grid layout.  This markup change seems to fix the image resize issue. Double-checked by slowing down the network speed and running a capture filmstrip thingy on Chrome - images come in at the correct size.

Test: `/videos/dude-this-is-a-really-nice-vidyo`