### PR TITLE
Fix layouts for article, articles, podcasts.

### DIFF
--- a/_assets/stylesheets/pages/_articles.scss
+++ b/_assets/stylesheets/pages/_articles.scss
@@ -54,7 +54,6 @@
   footer {
     font-size: 1rem;
     margin-top: 30px;
-    margin-bottom: 120px;
 
     .custom_images svg {
       height: 21px;

--- a/_assets/stylesheets/pages/_podcast.scss
+++ b/_assets/stylesheets/pages/_podcast.scss
@@ -25,8 +25,7 @@
     }
 
     @media screen and (min-width: $screen-sm) {
-      // First and second child
-      &:nth-child(-n+2) {
+      &:nth-child(2) {
         margin-top: 0;
       }
     }

--- a/articles.html
+++ b/articles.html
@@ -27,7 +27,7 @@ paginate:
     </div>
   </div>
 
-  <div class="push-ends">
+  <div class="push-top">
     {% include _pagination.html collection="articles" remote=true label="articles" %}
   </div>
 </div>


### PR DESCRIPTION
### Problem
/podcasts, /articles and article detail pages weren't working with the new 120px spacing layout.

### Solution
Change markup to support new consistent layout.