### PR TITLE
Defect/de5682 videos nav layout

### DIFF
--- a/_assets/stylesheets/_media-label.scss
+++ b/_assets/stylesheets/_media-label.scss
@@ -3,7 +3,6 @@
   right: 0;
   bottom: 0;
   padding: 6px 8px;
-  z-index: 1;
 
   .icon {
     width: 12px;

--- a/_assets/stylesheets/_sidebar-navigation.scss
+++ b/_assets/stylesheets/_sidebar-navigation.scss
@@ -10,6 +10,10 @@
 
   .dropdown-menu {
     right: 0;
+
+    > li > a {
+      white-space: normal;
+    }
   }
 
   @media screen and (min-width: $screen-md) {


### PR DESCRIPTION
### Problem
Long video tags don't wrap, resulting in the link running off the screen on mobile and the sidebar navigation covering the videos on desktop.

### Solution
Add word wrapping to the links constrains the sidebar and dropdown element widths.

**Bonus fix:** The `z-index` rule on the `.media-label` element (media type symbol on the cards) was breaking the stack order of the page, causing it to appear over the dropdown navigation on mobile. I removed this rule and found there was no need for this rule in the first place - absolute positioning puts this element over top it's relative positioned parent anyways.