### PR TITLE
Add styles and logic supporting album tracks.

### DIFF
--- a/_assets/stylesheets/pages/_songs.scss
+++ b/_assets/stylesheets/pages/_songs.scss
@@ -29,4 +29,19 @@
     max-width: 360px;
     width: 100%;
   }
+
+  .tracks {
+    li a {
+      font-size: 19px;
+      color: $cr-white;
+      opacity: .8;
+      text-transform: capitalize;
+
+      &:hover,
+      &:focus {
+        color: $cr-cyan-light;
+        text-decoration: none;
+      }
+    }
+  }
 }

--- a/_layouts/album.html
+++ b/_layouts/album.html
@@ -30,6 +30,17 @@ layout: default
 
             {% include _external-music-links.html %}
 
+            {% assign album = site.songs | where: 'album_title', page.title %}
+            {% if album.size > 0 %}
+            <div class="tracks text-center">
+              <h3 class="font-size-large font-family-base-light text-white">tracklist</h3>
+              <ul class="list-unstyled">
+                {% for song in album %}
+                <li><a href="{{ song.url }}">{{ song.title }}</a></li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Add styles and logic supporting the addition of album tracks from the [design](https://projects.invisionapp.com/share/WRGQZ5E4N3A#/screens/294618347). 

I'm using the song frontmatter value for `album_title` to determine what tracks are listed on each album. 

No supporting PR.