### PR TITLE
US13832 Remove Overlay from Podcast Header

### DIFF
--- a/_assets/stylesheets/pages/_podcast.scss
+++ b/_assets/stylesheets/pages/_podcast.scss
@@ -108,7 +108,6 @@
     }
 
     .header-content {
-      background-color: rgba($cr-black, 0.2);
       padding: 1rem 0;
 
       @media screen and (min-width: $screen-sm) {


### PR DESCRIPTION
Problem: The header background image on /podcasts had an overlay

Solution: remove it

No corresponding PRs