### PR TITLE
DE5742 Podcasts Detail Page

### DIFF
--- a/_assets/stylesheets/pages/_podcast.scss
+++ b/_assets/stylesheets/pages/_podcast.scss
@@ -139,7 +139,7 @@
     margin-top: 1.875rem;
 
     @media screen and (min-width: $screen-sm) {
-      margin-top: 7rem;
+      margin-top: 9.5rem;
     }
 
     & p {

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -9,7 +9,7 @@ layout: default
       <div class="row">
         <div class="col-sm-10 col-sm-offset-1">
           <div class="episode-header">
-            <ol class="breadcrumb hard-sides hard-top text-white">
+            <ol class="breadcrumb hard text-white">
               <li><a href="/">Media</a></li>
               <li><a href="/podcasts">Podcasts</a></li>
               <li><a href="{{ podcast.url }}">{{ podcast.title }}</a></li>
@@ -20,7 +20,7 @@ layout: default
                 <img src="{{ page.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_square }}" alt="{{ podcast.title }}" sizes="{{ site.image_sizes.episode_thumb }}" data-optimize-img>
               </div>
 
-              <h1 class="font-family-condensed-extra font-size-h3 text-uppercase text-white flush-top">{{ page.title }}</h1>
+              <h1 class="font-family-condensed-extra font-size-h3 text-uppercase text-white flush-ends">{{ page.title }}</h1>
             </div>
           </div>
         </div>
@@ -45,7 +45,7 @@ layout: default
       </div>
     </div>
 
-    <div class="row push-bottom soft-half-bottom">
+    <div class="row push-bottom soft-bottom">
       <div class="col-sm-8 col-sm-offset-2">
         {% for author_name in podcast.authors %}
           {% assign author = site.authors | where:"name", author_name | first %}

--- a/_layouts/podcast.html
+++ b/_layouts/podcast.html
@@ -62,7 +62,7 @@ layout: default
         {% endfor%}
       </div>
     </div>
-    <div class="row push-bottom">
+    <div class="row push-bottom soft-half-bottom">
       <div class="col-sm-8 col-sm-offset-2">
         {% include _social-share.html %}
       </div>

--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -65,7 +65,7 @@ layout: default
       <div class="col-sm-10 col-sm-offset-1">
         {% assign messages = page.associations['videos'] %}
         {% if messages.size > 1 %}
-        <section class="push-bottom">
+        <section class="push-bottom soft-quarter-bottom">
           <h2 class="component-header flush-top">In This Series</h2>
 
           <div class="cards-3x">


### PR DESCRIPTION
Problem:
On Podcast Page: Need more space between image and content (increased margin from 7rem to 9.5rem)

Additional solving:
Also increased spacing between headers on series, podcast, and episode templates to get them closer to 60px

On Episode page: Decreased padding on breadcrumbs and decrease margin on h1
