### PR TITLE
Update default permalink for site and change :slug to :title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ url: "https://media.crossroads.net" # the base hostname & protocol for your site
 image: "https://crds-cms-uploads.imgix.net/content/images/cr-social-sharing-still-bg.jpg"
 
 # disable_hubspot: true
-permalink: pretty
+permalink: /:collection/:title
 
 markdown: kramdown
 plugins:
@@ -21,6 +21,7 @@ exclude:
   - package.json
   - README.md
   - _migrations
+  - spec
   - vendor
 
 include:
@@ -31,36 +32,29 @@ collections_dir: collections
 collections:
   articles:
     output: true
-    permalink: /articles/:slug
+    permalink: /:collection/:title
   topics:
     output: true
-    permalink: /topics/:path
   authors:
     output: true
-    permalink: /:collection/:path
   podcasts:
     output: true
-    permalink: /:collection/:slug
   episodes:
     output: true
-    permalink: /podcasts/:podcast_slug/:slug
+    permalink: /podcasts/:podcast_slug/:title
   albums:
     output: true
-    permalink: /:collection/:slug
   songs:
     output: true
-    permalink: /:collection/:slug
   videos:
     output: true
-    permalink: /:collection/:slug
   series:
     output: true
-    permalink: /:collection/:slug
   tags:
     output: false
   messages:
     output: true
-    permalink: /series/:series_slug/:slug
+    permalink: /series/:series_slug/:title
 
 merged_collections:
   recent_media:


### PR DESCRIPTION
### Problem
Media urls with underscores have underscores stripped from them.

### Solution
Changing `:slug` to `:title`, as it keeps underscores. Per [documentation](https://jekyllrb.com/docs/permalinks/#template-variables), title defaults to the file name unless a slug has been added to the frontmatter.

I updated the config `permalink` value to point to `/:collection/:title` and removed the redundant values for the other media types. Articles is an exception - for some reason it defaults back to adding the publish date to the url, so it would look like `/articles/08-22-2018-another-image-test` instead of `/articles/another-image-test`.

Hid spec files from build.

### Test
`/series/test-series-with-___/`