### PR TITLE
US13811 - Featured Content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,7 +69,7 @@ merged_collections:
   recent_media:
     merge:
       - articles
-      - videos
+      - songs
     sort: date desc
 
 contentful:

--- a/_plugins/generators/features_generator.rb
+++ b/_plugins/generators/features_generator.rb
@@ -8,8 +8,10 @@ module Jekyll
       site.collections['features'].docs.each do |feature|
         # IDs of the entries attached to the feature in Contentful.
         doc_ids = feature.data['doc_ids']
-        # Using the IDs, select the doc objects from the site.
+        # Using the IDs, select the doc objects from the site and maintain the
+        # sort order of the doc_ids.
         docs = docs.select { |d| doc_ids.include?(d.data['id']) }
+                   .sort_by { |d| doc_ids.index(d.data['id']) }
         # Set the doc objects to the `docs` data attribute for the feature.
         feature.data['docs'] = docs
       end

--- a/_plugins/generators/features_generator.rb
+++ b/_plugins/generators/features_generator.rb
@@ -7,7 +7,7 @@ module Jekyll
       # Cycle through each of the features in the sites' features collection.
       site.collections['features'].docs.each do |feature|
         # IDs of the entries attached to the feature in Contentful.
-        doc_ids = feature.data['doc_ids']
+        doc_ids = feature.data['doc_ids'] || []
         # Using the IDs, select the doc objects from the site and maintain the
         # sort order of the doc_ids.
         docs = docs.select { |d| doc_ids.include?(d.data['id']) }

--- a/index.html
+++ b/index.html
@@ -12,24 +12,34 @@ paginate:
 ---
 
 {% assign feature_obj = site.features | where: 'page_path', page.url | first %}
+{% assign managed_features = feature_obj.docs %}
 
-{% for item in feature_obj.docs limit: 1 %}
-  {% include _overlay-card.html size="xl" %}
-{% endfor %}
+{% if managed_features.size > 0 %}
+  {% assign item = feature_obj.docs | first %}
+{% else %}
+  {% assign item = site.recent_media | first %}
+{% endif %}
+{% include _overlay-card.html size="xl" %}
 
 <div class="container push-top">
   <div class="row">
     <div class="col-md-8">
-      <div class="push-bottom">
-        <h2 class="collection-header push-bottom text-gray-light">featured media</h2>
-        {% assign features = feature_obj.docs | slice: 1, 100 %}
-        {% for item in features %}
-          <div class="soft-bottom">
-            {% include _overlay-card.html %}
-          </div>
-        {% endfor %}
-      </div>
-      {% assign recent_media = site.recent_media | slice: 1, 8 %}
+      {% if managed_features.size > 1 %}
+        <div class="push-bottom">
+          <h2 class="collection-header push-bottom text-gray-light">featured media</h2>
+          {% assign features = feature_obj.docs | slice: 1, 100 %}
+          {% for item in features %}
+            <div class="soft-bottom">
+              {% include _overlay-card.html %}
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+      {% if managed_features.size > 0 %}
+        {% assign recent_media = site.recent_media | slice: 0, 8 %}
+      {% else %}
+        {% assign recent_media = site.recent_media | slice: 1, 8 %}
+      {% endif %}
       {% if recent_media.size > 0 %}
         <div>
           <h2 class="collection-header text-gray-light push-bottom">most recent</h2>


### PR DESCRIPTION
This continues the original story by adding the following logic:

---

In the recent media section, update to display most recent articles and songs (instead of articles and videos).

If there is no matching featured media entry in Contentful, or if the entry's "entries" field is empty, display the four most recent articles/songs.

If the featured media entry has only one associated entry, it should be shown as the main jumbotron on the landing page, but the "featured media" section should not be shown, only the "recent media" section.

---

To test:
 
1. Unpublish featured media entry, then the landing page should show the most recent article/song as the jumbotron, and then show the next eight articles/songs under recent media.
2. Republish the entry, and the landing page should show the entries as the jumbotron and in the featured media section, maintaining the order from Contentful.
3. Remove all but one entry from the entries field. The main jumbotron should still show the featured entry, but only the recent media section should be shown, since there are no additional featured items.

_Testing may have to be done locally since the content is locked in with these previews._