### PR TITLE
Defect/de5745 song detail image

### DIFF
--- a/_assets/stylesheets/pages/_songs.scss
+++ b/_assets/stylesheets/pages/_songs.scss
@@ -10,9 +10,8 @@
     background: linear-gradient(to bottom, transparent, rgba(23,23,23,1) 85%);
   }
 
-  .media-artwork {
-    box-shadow: 0 0 .5rem 0 rgba($cr-black, 15);
-    width: 100%;
+  > .bg-charcoal {
+    padding-bottom: 90px;
   }
 
   .external-music-links {
@@ -46,6 +45,10 @@
   @media screen and (min-width: $screen-sm) {
     > header {
       padding: 390px 0 2rem;
+    }
+
+    > .bg-charcoal {
+      padding-bottom: 60px;
     }
 
     .external-music-links {

--- a/_assets/stylesheets/pages/_songs.scss
+++ b/_assets/stylesheets/pages/_songs.scss
@@ -27,6 +27,22 @@
     }
   }
 
+  .embed-video {
+    .card-title {
+      font-size: $font-size-small;
+      line-height: 1.3;
+    }
+
+    .embed-info {
+      display: flex;
+      justify-content: space-between;
+
+      div:first-child{
+        margin-right: .5rem;
+      }
+    }
+  }
+
   @media screen and (min-width: $screen-sm) {
     > header {
       padding: 390px 0 2rem;
@@ -38,6 +54,13 @@
           display: block;
           padding: 0;
         }
+      }
+    }
+
+    .embed-video {
+      .card-title {
+        font-size: 21px;
+        line-height: .9;
       }
     }
   }

--- a/_assets/stylesheets/pages/_songs.scss
+++ b/_assets/stylesheets/pages/_songs.scss
@@ -15,9 +15,30 @@
     width: 100%;
   }
 
+  .external-music-links {
+    ul {
+      list-style: none;
+      padding-left: 0;
+
+      li {
+        display: inline-block;
+        padding: 0 .5rem;
+      }
+    }
+  }
+
   @media screen and (min-width: $screen-sm) {
     > header {
       padding: 390px 0 2rem;
+    }
+
+    .external-music-links {
+      ul {
+        li {
+          display: block;
+          padding: 0;
+        }
+      }
     }
   }
 }

--- a/_assets/stylesheets/pages/_songs.scss
+++ b/_assets/stylesheets/pages/_songs.scss
@@ -1,24 +1,24 @@
 .song-detail-tpl {
-  .jumbotron {
-    padding-top: 10rem;
-    padding-bottom: 3.75rem;
-
-    @media screen and (min-width: $screen-md) {
-      padding-top: 15rem;
-    }
-
-    .card .block {
-      display: block;
-    }
+  > header {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    padding: 138px 0 1rem;
   }
 
   .bg-overlay {
-    background: linear-gradient(to bottom, transparent, rgba(23,23,23,1) 50%, rgba(23,23,23,1) 100%);
+    background: linear-gradient(to bottom, transparent, rgba(23,23,23,1) 85%);
   }
 
   .media-artwork {
     box-shadow: 0 0 .5rem 0 rgba($cr-black, 15);
     width: 100%;
+  }
+
+  @media screen and (min-width: $screen-sm) {
+    > header {
+      padding: 390px 0 2rem;
+    }
   }
 }
 

--- a/_includes/_external-music-links.html
+++ b/_includes/_external-music-links.html
@@ -1,7 +1,7 @@
 {% if page.spotify_url.size > 1 or page.apple_music_url.size > 1 or page.youtube_url.size > 1 or page.google_play_url.size > 1 %}
-  <div class="border-white-15 bg-black-50 text-center">
+  <div class="border-white-15 soft-half-sides bg-black-50 text-center">
     <h3 class="text-lowercase font-size-large font-family-base-light text-white">Stream or Buy</h3>
-    <ul class="list-inline">
+    <ul class="list-unstyled">
       {% if page.spotify_url.size > 1 %}
         <li class="push-bottom"><a href="{{ page.spotify_url }}"><img class="push-quarter-top" src="//dz6ito7tas43n.cloudfront.net/images/spotify.svg" alt="spotify" style="height: 2rem;"></a></li>
       {% endif %}

--- a/_includes/_external-music-links.html
+++ b/_includes/_external-music-links.html
@@ -1,7 +1,7 @@
 {% if page.spotify_url.size > 1 or page.apple_music_url.size > 1 or page.youtube_url.size > 1 or page.google_play_url.size > 1 %}
-  <div class="border-white-15 soft-half-sides bg-black-50 text-center">
+  <div class="external-music-links border-white-15 soft-half-sides bg-black-50 text-center">
     <h3 class="text-lowercase font-size-large font-family-base-light text-white">Stream or Buy</h3>
-    <ul class="list-unstyled">
+    <ul>
       {% if page.spotify_url.size > 1 %}
         <li class="push-bottom"><a href="{{ page.spotify_url }}"><img class="push-quarter-top" src="//dz6ito7tas43n.cloudfront.net/images/spotify.svg" alt="spotify" style="height: 2rem;"></a></li>
       {% endif %}

--- a/_includes/_video-card.html
+++ b/_includes/_video-card.html
@@ -25,9 +25,6 @@
         <h5 class="card-title font-size-smaller push-quarter-bottom">{{ video.title }}</h5>
     {% endif %}
         <div class="font-size-smaller push-quarter-top push-half-bottom">
-          {% if video.topic != nil %}
-            <a class="text-gray" href="{{ topic.url }}">{{ video.topic }} &#xB7;</a>
-          {% endif %}
           {% for person in video.authors %}
             {% assign video_author = site.authors | where: "name", person | first %}
             <a class="text-gray" href="{{ video_author.url }}">{{ person }}</a>
@@ -35,6 +32,9 @@
             <span class="text-gray">&amp;</span>
             {% endunless %}
           {% endfor %}
+          {% if video.topic != nil %}
+            <a class="text-gray" href="{{ topic.url }}">{{ video.topic | prepend: '∙ ' }}</a>
+          {% endif %}
         </div>
       </a>
   </div>

--- a/_includes/_yt-subscribe-btn.html
+++ b/_includes/_yt-subscribe-btn.html
@@ -1,9 +1,9 @@
 <a href="{{ include.url }}" role="button" class="btn bg-gray-dark d-flex soft-quarter-ends flush">
   <div class="d-flex flex-column push-quarter-right align-items-start">
-    <span class="font-size-small push-quarter-bottom">YouTube</span>
+    <span class="font-size-small push-quarter-bottom text-white">YouTube</span>
     <span class="font-size-smallest text-gray-light text-uppercase">Subscribe</span>
   </div>
-  <svg class="icon" viewBox="0 0 256 256">
+  <svg class="icon text-white" viewBox="0 0 256 256">
     <use xlink:href="/assets/svgs/icons.svg#youtube"></use>
   </svg>
 </a>

--- a/_layouts/song.html
+++ b/_layouts/song.html
@@ -75,7 +75,6 @@ layout: default
               </div>
             {% else %}
               {% include _video-card.html imgix_size="1x" theme="dark" %}
-              <!-- 🚨 Button text should be white -->
             {% endif %}
           {% endfor %}
 

--- a/_layouts/song.html
+++ b/_layouts/song.html
@@ -46,31 +46,36 @@ layout: default
           <!-- Featured Video -->
           {% for video in videos limit: 1 %}
             {% if video.source_url %}
-              <div class="card relative push-bottom">
+              <div class="card relative push-bottom embed-video">
                 {% assign video_id = video.source_url | youtube_id %}
                 <div class="push-ends">
                   {% include _yt-embed.html %}
                 </div>
-                <div class="pull-right">
-                  {% include _yt-subscribe-btn.html url="https://www.youtube.com/user/crdschurch" %}
-                </div>
-                <h6 class="card-title text-white push-quarter-bottom">{{ video.title }}</h6>
-                <div class="font-size-smaller">
-                  {% if video.topic != nil %}
-                    <a class="text-gray-light" href="{{ topic.url }}">{{ video.topic }} &#xB7;</a>
-                  {% endif %}
+                <div class="embed-info">
+                  <div>
+                    <h6 class="card-title text-white push-quarter-bottom flush-top">{{ video.title }}</h6>
+                    <div class="font-size-smaller">
+                      {% for person in video.authors %}
+                        {% assign video_author = site.authors | where: "name", person | first %}
+                        <a class="text-gray-light" href="{{ video_author.url }}">{{ person }}</a>
+                        {% unless forloop.last %}
+                        <span class="text-gray-light">&amp;</span>
+                        {% endunless %}
+                      {% endfor %}
 
-                  {% for person in video.authors %}
-                    {% assign video_author = site.authors | where: "name", person | first %}
-                    <a class="text-gray-light" href="{{ video_author.url }}">{{ person }}</a>
-                    {% unless forloop.last %}
-                    <span class="text-gray-light">&amp;</span>
-                    {% endunless %}
-                  {% endfor %}
+                      {% if video.topic != nil %}
+                        <a class="text-gray-light" href="{{ topic.url }}">{{ video.topic | prepend: '∙ ' }}</a>
+                      {% endif %}
+                    </div>
+                  </div>
+                  <div>
+                    {% include _yt-subscribe-btn.html url="https://www.youtube.com/user/crdschurch" %}
+                  </div>
                 </div>
               </div>
             {% else %}
               {% include _video-card.html imgix_size="1x" theme="dark" %}
+              <!-- 🚨 Button text should be white -->
             {% endif %}
           {% endfor %}
 

--- a/_layouts/song.html
+++ b/_layouts/song.html
@@ -48,7 +48,7 @@ layout: default
             {% if video.source_url %}
               <div class="card relative push-bottom embed-video">
                 {% assign video_id = video.source_url | youtube_id %}
-                <div class="push-ends">
+                <div class="push-bottom">
                   {% include _yt-embed.html %}
                 </div>
                 <div class="embed-info">

--- a/_layouts/song.html
+++ b/_layouts/song.html
@@ -16,28 +16,33 @@ layout: default
 {% endif %}
 
 <div class="song-detail-tpl">
-  <div class="jumbotron jumbotron-xl" style="background-image: url('{{ bg_img | imgix: site.imgix }}'); background-size: cover;" data-optimize-bg-img>
+  <header style="background-image: url('{{ bg_img | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}')" data-optimize-bg-img>
     <div class="bg-overlay"></div>
-    <div class="container jumbotron-content">
-      <div class="row d-flex flex-column flex-md-row">
-        <div class="col-md-7 col-md-offset-1 text-left push-bottom">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1">
           <ol class="breadcrumb hard-sides text-white">
             <li><a href="/">Media</a></li>
             <li><a href="/music">Music</a></li>
           </ol>
-
-          <h2 class="font-family-condensed-extra font-size-giant text-uppercase text-white flush-top push-bottom">{{ page.title }}</h2>
-
-          <div class="font-size-base white-faded markdown">{{ page.content }}</div>
-        </div>
-        <div class="col-md-3 push-bottom">
-          {% include _external-music-links.html %}
+          <div class="row">
+            <div class="col-md-9">
+              <h1 class="text-white font-family-condensed-extra text-uppercase font-size-giant flush-top">{{ page.title }}</h1>
+              <div class="text-white soft-half-top">{{ page.content }}</div>
+            </div>
+            <div class="col-md-3">
+              {% include _external-music-links.html %}
+            </div>
+          </div>
         </div>
       </div>
-      {% if videos.size > 0 %}
-      <div class="row text-left">
+    </div>
+  </header>
+  {% if videos.size > 0 %}
+  <div class="bg-charcoal">
+    <div class="container">
+      <div class="row">
         <div class="col-md-10 col-md-offset-1">
-
           <!-- Featured Video -->
           {% for video in videos limit: 1 %}
             {% if video.source_url %}
@@ -78,12 +83,11 @@ layout: default
               {% endfor %}
             </div>
           </div>
-
         </div>
       </div>
-      {% endif %}
     </div>
   </div>
+  {% endif %}
 </div>
 
 <div class="container">


### PR DESCRIPTION
### Problem
The page background image had a pixelated appearance on some songs.

### Solution
I determined that the pixelated background image was due to the fact that the content container had a variable height depending on what data was added each song, i.e., if a song just had links, title and description the background looked fine, but if one included a Youtube embed and/or related videos it would stretch the image out vertically.

To fix this, I modified the markup, splitting the title, description text and shareable links into their own container with background image and gradient overlay. Beneath is a new container with a solid dark gray background. This ensures the background and gradient on every song page looks consistent regardless of the content added.

I also made changes to the page to keep the look in-line with Rob's designs [here](https://app.zeplin.io/project/5acf6d62553bdae0669efdd2/screen/5afc56346c3cd87021148a46). Some changes include:
- Switching the author and topic details on the related videos
- Updating the shareable share/buy links to display `inline-block` on mobile and `block` on desktop
- Changing the song title to an `h1`
- Modifying the font size of the embedded video's title
- Updating the layout on the embedded video's info (title, performer, YT button) to account for longer titles/performers/categories. This change adds space between text details and the button.

### Testing
Navigated to `/music/` and select the songs available there. There's a wide array of songs with different data, so check these pages on mobile and desktop to see that the changes aren't breaking.