### PR TITLE
Defect/de5794 music landing card styles

### DIFF
--- a/_assets/stylesheets/pages/_music.scss
+++ b/_assets/stylesheets/pages/_music.scss
@@ -1,10 +1,75 @@
-.music-tpl .breadcrumb-container {
-  position: absolute;
-  top: 122px;
-  left: 15px;
-  z-index: 1;
+.music-tpl {
+  .breadcrumb-container {
+    margin-top: 3.75rem;
+    position: absolute;
+    z-index: 1;
+  }
 
-  @media (min-width: $screen-sm) {
-    left: 60px;
+  // Splash cards behave different from overlay cards in that they have no gradient overlay, have no margins, are full-width and full-height, and are intended to fulfill some kinda singular conversion using a CTA. Just like a splash page - but in card form.
+  .splash-card {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    display: block;
+    height: 650px;
+    max-height: calc(100vh - 140px);
+    position: relative;
+
+    .content {
+      bottom: 0;
+      margin-bottom: 45px;
+      position: absolute;
+
+      > * {
+        color: $cr-white;
+      }
+    }
+
+    .meta {
+      font-size: 13px;
+      line-height: 1.3;
+      font-weight: 600;
+      margin-bottom: 0;
+      opacity: .8;
+      text-transform: uppercase;
+    }
+
+    .title {
+      font-family: $condensed-extra-font-face;
+      font-size: 4rem;
+      line-height: .9;
+      text-transform: uppercase;
+    }
+
+    .tagline {
+      font-family: $base-font-face;
+      font-size: $font-size-base;
+      font-style: normal;
+      line-height: $line-height-base;
+      margin-bottom: 0;
+    }
+
+    .btn {
+      margin-top: 30px;
+    }
+  }
+
+  @media screen and (min-width: $screen-sm) {
+    .splash-card {
+      height: 900px;
+      max-height: calc(100vh - 72px);
+
+      .content {
+        margin-bottom: 60px;
+      }
+
+      .title {
+        font-size: 5.625rem;
+      }
+
+      .tagline {
+        font-size: $font-size-large;
+      }
+    }
   }
 }

--- a/music.html
+++ b/music.html
@@ -8,10 +8,12 @@ paginate:
 ---
 <div class="music-tpl">
   <div class="push-bottom">
-    <div class="breadcrumb-container">
-      <ol class="breadcrumb hard flush-bottom text-white">
-        <li><a href="/">Media</a></li>
-      </ol>
+    <div class="container">
+      <div class="breadcrumb-container">
+        <ol class="breadcrumb hard flush-bottom text-white">
+          <li><a href="/">Media</a></li>
+        </ol>
+      </div>
     </div>
     {% if page.songs.page == 1 %}
       {% assign featured = page.songs.offset %}

--- a/music.html
+++ b/music.html
@@ -1,6 +1,5 @@
 ---
-layout: default_footer_flush
-default_cta: Check It Out
+layout: default
 paginate:
   songs:
     offset: 4

--- a/music.html
+++ b/music.html
@@ -18,29 +18,29 @@ paginate:
     {% if page.songs.page == 1 %}
       {% assign featured = page.songs.offset %}
       {% for item in featured %}
-        <div class="overlay-card overlay-card-xl">
-          <a class="overlay-card-link" href="{{ item.url }}">
-            <div class="overlay-card-image">
-              {% if item.image %}
-                <img src="{{ item.image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{{ site.image_sizes.card_2x }}" alt="{{ item.image.title }}" data-optimize-img />
+      <a href="{{ item.url }}" class="splash-card" style="background-image:url('{% if item.image %}{{ item.image | imgix: site.imgix }}{% else %}{{ site.default_image | imgix: site.imgix }}{% endif %}?{{ site.imgix_params.placeholder_sixteen_nine }}')" sizes="{{ site.image_sizes.full_width }}" alt="{{ item.image.title }}" data-optimize-bg-img>
+        <div class="container">
+          <div class="content">
+            {% if item.featured_label %}
+            <p class="meta flush-ends">{{ item.featured_label }}</p>
+            {% endif %}
+
+            <h2 class="title flush-bottom push-top">{{ item.title | truncate: 55 }}</h2>
+
+            {% if item.featured_text %}
+            <p class="tagline flush-bottom push-top">{{ item.featured_text }}</p>
+            {% endif %}
+
+            <div class="btn btn-outline btn-white">
+              {% if item.call_to_action %}
+                {{ item.call_to_action }}
               {% else %}
-                <img src="{{ site.default_image | imgix: site.imgix }}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{{ site.image_sizes.card_2x }}" alt="{{ item.image.title }}" data-optimize-img />
+                Check it out
               {% endif %}
             </div>
-
-            <div class="overlay-card-content block">
-              <p class="overlay-card-category">{{ item.featured_label }}</p>
-              <h2 class="overlay-card-title">{{ item.title | truncate: 55 }}</h2>
-              <p class="overlay-card-author">{{ item.featured_text }}</p>
-
-              {% include _media-label.html source=item %}
-
-              <a class="btn btn-white btn-outline" href="{{ item.url }}">
-                {% if item.call_to_action %} {{ item.call_to_action }} {% else %} {{ page.default_cta }} {% endif %}
-              </a>
-            </div>
-          </a>
+          </div>
         </div>
+      </a>
       {% endfor %}
     {% endif %}
   </div>

--- a/music.html
+++ b/music.html
@@ -45,7 +45,7 @@ paginate:
     {% endif %}
   </div>
 
-  <div class="container push-bottom">
+  <div class="container">
     <div class="cards-4x cards-2x-xs" data-page="songs">
       <div class="row push-top" data-page-number="{{ page.songs.page }}">
         {% for card in page.songs.docs %}


### PR DESCRIPTION
### Problem
Overlay cards are being used on `/music` don't match the design [here](https://app.zeplin.io/project/5acf6d62553bdae0669efdd2/screen/5afc563a13965b310fa0d31f).

### Solution
Create new card styles matching the design.  These card styles only exist on `/music` and have been added to the music stylesheet but can be extracted to the generic cards styles later.

### Testing
`/music`