### PR TITLE
DE5703 - Article metadata

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -28,23 +28,9 @@
   {% asset application.scss !integrity %}
 
   <title>{% if page.title and page.title != site.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}</title>
-  <meta name="description" content="
-  {% if page.lead %}
-    {{ page.lead | strip_html | truncate: 160 }}
-  {% elsif page.excerpt %}
-    {{ page.excerpt | strip_html | truncate: 160 }}
-  {% else %}
-    {{ site.description | strip_html | truncate: 160 }}
-  {% endif %}">
+  <meta name="description" content="{% if page.lead %}{{ page.lead | strip_html | truncate: 160 }}{% elsif page.excerpt %}{{ page.excerpt | strip_html | truncate: 160 }}{% else %}{{ site.description | strip_html | truncate: 160 }}{% endif %}">
   <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
-  <meta property="og:description" content="
-  {% if page.lead %}
-    {{ page.lead | strip_html | truncate: 160 }}
-  {% elsif page.excerpt %}
-    {{ page.excerpt | strip_html | truncate: 160 }}
-  {% else %}
-    {{ site.description | strip html | truncate: 160 }}
-  {% endif %}">
+  <meta property="og:description" content="{% if page.lead %}{{ page.lead | strip_html | truncate: 160 }}{% elsif page.excerpt %}{{ page.excerpt | strip_html | truncate: 160 }}{% else %}{{ site.description | strip html | truncate: 160 }}{% endif %}">
   <meta property="og:image" content="{% if page.image %}https:{{ page.image | escape }}{% else %}{{ site.image | escape }}{% endif %}">
   <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <meta property="og:site_name" content="{{ site.title }}">

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -28,9 +28,23 @@
   {% asset application.scss !integrity %}
 
   <title>{% if page.title and page.title != site.title %}{{ page.title | escape }} | {% endif %}{{ site.title | escape }}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="description" content="
+  {% if page.lead %}
+    {{ page.lead | strip_html | truncate: 160 }}
+  {% elsif page.excerpt %}
+    {{ page.excerpt | strip_html | truncate: 160 }}
+  {% else %}
+    {{ site.description | strip_html | truncate: 160 }}
+  {% endif %}">
   <meta property="og:title" content="{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
-  <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta property="og:description" content="
+  {% if page.lead %}
+    {{ page.lead | strip_html | truncate: 160 }}
+  {% elsif page.excerpt %}
+    {{ page.excerpt | strip_html | truncate: 160 }}
+  {% else %}
+    {{ site.description | strip html | truncate: 160 }}
+  {% endif %}">
   <meta property="og:image" content="{% if page.image %}https:{{ page.image | escape }}{% else %}{{ site.image | escape }}{% endif %}">
   <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <meta property="og:site_name" content="{{ site.title }}">


### PR DESCRIPTION
### Problem
Meta descriptions in `<head>` should reflect the first line of text, regardless of whether it's lead or body copy.

### Solution
Update description metadata to use lead text if available, followed by an excerpt of the post content, and if neither is available - use the site description.