### PR TITLE
Add conditional logic to only show discussion if present.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unf_ext (0.0.7.5-x64-mingw32)
-    wdm (0.1.1)
 
 PLATFORMS
   ruby
@@ -251,7 +250,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier
   video-tags (~> 0.0.1)!
-  wdm (~> 0.1.0)
 
 BUNDLED WITH
    1.16.4

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -35,9 +35,11 @@ layout: default
       </main>
       {% endif %}
 
+      {% if page.discussion %}
       <div class="col-md-8 col-md-offset-2">
         {% include _discussion-questions.html %}
       </div>
+      {% endif %}
 
       <footer class="col-md-8 col-md-offset-2">
         <p class="flush-bottom">Written by <a href="{{ author.url }}" data-author-name>{{ page.author | titleize }}</a></p>

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -65,7 +65,7 @@ layout: default
           {% include _tabs.html tabs=tabs %}
         {% endif %}
 
-        {% if page.series_slug %}
+        {% if page.series_slug and page.discussion %}
         <div class="push-bottom">
           {% include _discussion-questions.html %}
         </div>


### PR DESCRIPTION
### Problem
If no discussion questions associated with an article/message, then the discussion block should not appear.

### Solution
Add conditional logic to only show discussion object if an ID is present in the article/message frontmatter.

### Testing

| **should** have a discussion block | **should not** have a discussion block |
--- | --- 
`/series/spark-2018/week-1-how-do-we-think-about-depression` | `/series/spark-2018/week-1-how-do-we-think-about-depression-test3`
`/articles/test8` | `/articles/jakes-schedule-test`