### PR TITLE
[DE5842] Update videos template to have a wider layout.

### DIFF
--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -8,7 +8,7 @@ layout: default
   <div class="bg-charcoal">
     <div class="container">
       <div class="row">
-        <div class="col-md-8 col-md-offset-2">
+        <div class="col-md-10 col-md-offset-1">
 
           {% if video_id %}
           <div class="push-top soft-top">
@@ -59,47 +59,51 @@ layout: default
 
   <div class="container">
     <div class="row push-ends">
-      <div class="col-sm-4 col-md-5 col-sm-offset-2">
-        {% assign tabs = 'description transcription' | split: ' ' %}
-        {% if page.transcription or page.description %}
-          {% include _tabs.html tabs=tabs %}
-        {% endif %}
+      <div class="col-md-10 col-md-offset-1">
+        <div class="row">
+          <div class="col-md-9">
+            {% assign tabs = 'description transcription' | split: ' ' %}
+            {% if page.transcription or page.description %}
+              {% include _tabs.html tabs=tabs %}
+            {% endif %}
 
-        {% if page.series_slug and page.discussion %}
-        <div class="push-bottom">
-          {% include _discussion-questions.html %}
-        </div>
-        {% endif %}
+            {% if page.series_slug and page.discussion %}
+            <div class="push-bottom">
+              {% include _discussion-questions.html %}
+            </div>
+            {% endif %}
 
-        {% for author_name in page.authors %}
-        {% assign author = site.authors | where:"name", author_name | first %}
-        {% if author %}
-        {% if forloop.first %}<p class="flush-bottom">Featuring {% endif %}
-          <a href="{{ author.url }}">{{ author.name | titleize }}</a> {% if forloop.last == false %} and {% endif %} {% if forloop.last %}</p>{% endif%}
-          {% endif %}
-          {% endfor%}
-          <p>{{ page.date | format_date }} {% if page.video_duration != nil %}
-            <span class="divider push-quarter-sides">•</span> {{ page.video_duration }} {% endif %}</p>
+            {% for author_name in page.authors %}
+            {% assign author = site.authors | where:"name", author_name | first %}
+            {% if author %}
+            {% if forloop.first %}<p class="flush-bottom">Featuring {% endif %}
+              <a href="{{ author.url }}">{{ author.name | titleize }}</a> {% if forloop.last == false %} and {% endif %} {% if forloop.last %}</p>{% endif%}
+              {% endif %}
+              {% endfor%}
+              <p>{{ page.date | format_date }} {% if page.video_duration != nil %}
+                <span class="divider push-quarter-sides">•</span> {{ page.video_duration }} {% endif %}</p>
 
-          <div class="soft-half-top push-top">
-            {% include _social-share.html %}
+              <div class="soft-half-top push-top">
+                {% include _social-share.html %}
+              </div>
+
+              {% assign topic = site.topics | where: "title", page.topic | first %}
+              {% if page.topic %}
+              <p class="flush-bottom soft-top">
+                <strong>Topic</strong>
+              </p>
+              <ul class="list-inline">
+                <li>
+                  <a href="{{ topic.url }}">{{ topic.title }}</a>
+                </li>
+              </ul>
+              {% endif %}
+              {% include _tags_list.html %}
           </div>
-
-          {% assign topic = site.topics | where: "title", page.topic | first %}
-          {% if page.topic %}
-          <p class="flush-bottom soft-top">
-            <strong>Topic</strong>
-          </p>
-          <ul class="list-inline">
-            <li>
-              <a href="{{ topic.url }}">{{ topic.title }}</a>
-            </li>
-          </ul>
-          {% endif %}
-          {% include _tags_list.html %}
-      </div>
-      <div class="col-sm-4 col-md-3 soft-half-top">
-        {% include _subscribe-buttons.html content_type=page youtube=true row=false subscribe=false %}
+          <div class="col-md-3 soft-half-top">
+            {% include _subscribe-buttons.html content_type=page youtube=true row=false subscribe=false %}
+          </div>
+        </div>
       </div>
     </div>
 
@@ -112,7 +116,7 @@ layout: default
 
     {% if site.videos.size > 1 or messages.size > 1 %}
     <div class="push-top soft-top row">
-      <div class="col-sm-8 col-sm-offset-2">
+      <div class="col-md-10 col-md-offset-1">
 
         <section>
           <h2 class="component-header flush-top">


### PR DESCRIPTION
### Problem
The layout for messages/videos is too narrow. This doesn't match the design and makes the discussions block look goofy when available on messages.

### Solution
Bump up the width of the content from 8 columns, to 10. I made the breakpoint consistent (medium) for each content section.

### Testing
You can test this solution on any message or video page.