### PR TITLE
US15155 add sign-off section to articles

### DIFF
--- a/_assets/stylesheets/_signoff.scss
+++ b/_assets/stylesheets/_signoff.scss
@@ -1,0 +1,30 @@
+.signoff {
+  background: $cr-gray-lighter;
+  font-size: $font-size-small;
+  padding: 20px;
+  padding-top: 45px;
+
+  @media screen and (min-width: $screen-sm) {
+    padding: 45px;
+  }
+
+  h2, h3 {
+    font-size: 1.5rem;
+    font-weight: 500;
+    margin-top: 0;
+    margin-bottom: 6px;
+  }
+
+  ol, ul {
+    list-style: none;
+    padding-left: 0;
+
+    li {
+      margin-bottom: 20px;
+
+      &:first-of-type {
+        margin-top: 1.75rem;
+      }
+    }
+  }
+}

--- a/_assets/stylesheets/application.scss
+++ b/_assets/stylesheets/application.scss
@@ -19,4 +19,5 @@
 @import "tabs";
 @import "discussion-questions";
 @import "topic-cards";
-@import "rollcall"
+@import "rollcall";
+@import "signoff";

--- a/_config.yml
+++ b/_config.yml
@@ -58,15 +58,17 @@ collections:
   series:
     output: true
     permalink: /:collection/:title
+  messages:
+    output: true
+    permalink: /series/:series_slug/:title
   tags:
     output: false
   features:
     output: false
   discussions:
     output: false
-  messages:
-    output: true
-    permalink: /series/:series_slug/:title
+  signoffs:
+    output: false
 
 contentful:
   content_types:
@@ -301,6 +303,14 @@ contentful:
           intro: intro
           challenge: challenge
           discussion_questions: discussion_questions/question
+    signoffs:
+      id: signoff
+      body: body
+      frontmatter:
+        entry_mappings:
+          title: title
+          date: published_at
+          body: body
 
 
 defaults:

--- a/_config.yml
+++ b/_config.yml
@@ -304,7 +304,7 @@ contentful:
           challenge: challenge
           discussion_questions: discussion_questions/question
     signoffs:
-      id: signoff
+      id: sign_off
       body: body
       frontmatter:
         entry_mappings:

--- a/_includes/_signoff.html
+++ b/_includes/_signoff.html
@@ -1,0 +1,5 @@
+{% assign signoff = site.signoffs | sort: 'date' | reverse | first %}
+
+<section class="signoff">
+  {{ signoff.body | markdownify }}
+</section>

--- a/_includes/_signoff.html
+++ b/_includes/_signoff.html
@@ -1,5 +1,0 @@
-{% assign signoff = site.signoffs | sort: 'date' | reverse | first %}
-
-<section class="signoff">
-  {{ signoff.body | markdownify }}
-</section>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -41,6 +41,10 @@ layout: default
       </div>
       {% endif %}
 
+      <div class="col-md-8 col-md-offset-2 soft-top">
+        {% include _signoff.html %}
+      </div>
+
       <footer class="col-md-8 col-md-offset-2">
         <p class="flush-bottom">Written by <a href="{{ author.url }}" data-author-name>{{ page.author | titleize }}</a></p>
         <date data-post-date>{{ page.date | format_date }}</date>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -41,8 +41,11 @@ layout: default
       </div>
       {% endif %}
 
+      {% assign signoff = site.signoffs | sort: 'date' | reverse | first %}
       <div class="col-md-8 col-md-offset-2 soft-top">
-        {% include _signoff.html %}
+        <section class="signoff">
+          {{ signoff.body | markdownify }}
+        </section>
       </div>
 
       <footer class="col-md-8 col-md-offset-2">


### PR DESCRIPTION
This adds a sign off section to the bottom of all articles.

From the story: 

> This is a single entry that allows the admins to apply a global sign off the bottom of all articles. Style-wise, it should be similar to the article discussion questions - gray box w/ text, that's it and that's all. 

It is connected to  https://github.com/crdschurch/crds-contentful-migrations/pull/34