### PR TITLE
Defect/de5993 recent podcast episode

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,12 +101,13 @@ paginate:
       {% if page.podcasts.docs.size != 0 %}
         <div class="push-bottom soft-bottom">
           <h2 class="collection-header push-bottom text-gray-light">podcasts</h2>
-          {% assign featured = page.podcasts.docs | first %}
-          {% assign unfeatured_podcasts = page.podcasts.docs | slice: 1, 3 %}
+          {% assign featured = site.ordered_podcasts | first %}
+          {% assign unfeatured_podcasts = site.ordered_podcasts | slice: 1, 3 %}
+
           {% include _media-object-featured.html media_type="podcast" %}
           <hr>
           {% for media in unfeatured_podcasts %}
-            {% include _media-object.html count="7 episodes" media_type="podcast" %}
+            {% include _media-object.html media_type="podcast" %}
             {% unless forloop.last %}
               <hr>
             {% endunless %}

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@ paginate:
         </div>
       {% endif %}
 
-      {% if page.podcasts.docs.size != 0 %}
+      {% if site.podcasts.size > 0 %}
         <div class="push-bottom soft-bottom">
           <h2 class="collection-header push-bottom text-gray-light">podcasts</h2>
           {% assign featured = site.ordered_podcasts | first %}


### PR DESCRIPTION
### Problem
Podcasts on the homepage aren't ordered recent first.

### Solution
Implement Sean's podcast ordered generator. 