### PR TITLE
DE5996 images on podcast page resizing on load

### DIFF
--- a/_includes/_podcast-card.html
+++ b/_includes/_podcast-card.html
@@ -1,5 +1,5 @@
 <div class="card">
-  <a href="{{ podcast.url }}">
+  <a href="{{ podcast.url }}" class="relative">
     <img src="{% if podcast.image.url %}{{ podcast.image.url | imgix: site.imgix }}{% else %}{{ site.default_image | imgix: site.imgix }}{% endif %}?{{ site.imgix_params.placeholder_square }}" sizes="{{ site.image_sizes.cards_4x }}" data-optimize-img>
   </a>
   <div class="card-block hard-bottom">


### PR DESCRIPTION
Problem: Image sizes bounce from large to small when page loads. https://media.crossroads.net/podcasts/