### PR TITLE
DE6003 - Future series

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -94,9 +94,6 @@ contentful:
   series:
     map:
       date: starts_at
-  series:
-    map:
-      date: published_at
   video:
     map:
       date: published_at


### PR DESCRIPTION
### Problem
On `/series`, series that begin on a future date are displaying when they should not.

### Solution
It looks like a line was added to the config file that overwrote the original logic of mapping date to `starts_at`. I removed the overriding series mapping from config file ~and reached out the @seancdavis to see if this was an intentional change as part of the jekyll-contentful gem or an error~ that came about from a goofed merge.

### Test
Visit `/series`

