### PR TITLE
DE6050 - Add titles to pages

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Articles
 paginate:
   articles:
     per: 10

--- a/music.html
+++ b/music.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Music
 paginate:
   songs:
     offset: 4

--- a/perspectives.html
+++ b/perspectives.html
@@ -1,5 +1,6 @@
 ---
 layout: default_footer_flush
+title: Perspectives
 ---
 
 <div class="perspective-tpl">


### PR DESCRIPTION
### Problem
Titles aren't appearing on certain pages.

### Solution
Follow the pattern of other pages in adding a `title` tag to the frontmatter.

### Testing
Broken title tags include /articles, /music, and /perspectives.