### PR TITLE
DE6059 - Song bg

### DIFF
--- a/_assets/stylesheets/pages/_songs.scss
+++ b/_assets/stylesheets/pages/_songs.scss
@@ -8,6 +8,7 @@
 
   .bg-overlay {
     background: linear-gradient(to bottom, transparent, rgba(23,23,23,1) 85%);
+    top: 26%;
   }
 
   > .bg-charcoal {


### PR DESCRIPTION
### Problem
Background image is taller than the dark overlay, causing a thin line to appear in the layout between the song info and embedded video sections.

### Solution
Increase position of overlay to cover bg image.

### Testing
/songs/anybody-else