### PR TITLE
Defect/de6053 duration display

### DIFF
--- a/_includes/_media-label.html
+++ b/_includes/_media-label.html
@@ -13,8 +13,10 @@
       <span class="font-size-smallest">{{ read_time }} min read</span>
     {% endif %}
   {% elsif content_type == "video" or content_type == "message" %}
-    {% if include.source.video_duration %}<span class="font-size-smallest">{{ include.source.video_duration }} min watch</span>{% endif %}
-  {% elsif content_type == "song" or content_type == "episode" %}
+    {% if include.source.video_duration %}<span class="font-size-smallest">{{ include.source.video_duration }}</span>{% endif %}
+  {% elsif content_type == "song" %}
+    {% if include.source.audio_duration %}<span class="font-size-smallest">{{ include.source.audio_duration }}</span>{% endif %}
+  {% elsif content_type == "episode" %}
     {% if include.source.audio_duration %}<span class="font-size-smallest">{{ include.source.audio_duration }} min listen</span>{% endif %}
   {% endif %}
 

--- a/_includes/_media-label.html
+++ b/_includes/_media-label.html
@@ -19,7 +19,7 @@
   <svg class="icon" viewBox="0 0 256 256">
     {% if content_type == "article" %}
       <use xlink:href="/assets/svgs/icons.svg#media-article"></use>
-    {% elsif content_type == "video" %}
+    {% elsif content_type == "video" or content_type == "message" %}
       <use xlink:href="/assets/svgs/icons.svg#media-video"></use>
     {% elsif content_type == "song" %}
       <use xlink:href="/assets/svgs/icons.svg#media-music"></use>

--- a/_includes/_media-label.html
+++ b/_includes/_media-label.html
@@ -14,8 +14,12 @@
     {% endif %}
   {% elsif content_type == "video" or content_type == "message" %}
     {% if include.source.video_duration %}<span class="font-size-smallest">{{ include.source.video_duration }}</span>{% endif %}
-  {% elsif content_type == "song" or content_type == "episode" %}
+  {% elsif content_type == "song" %}
     {% if include.source.audio_duration %}<span class="font-size-smallest">{{ include.source.audio_duration }}</span>{% endif %}
+  {% elsif content_type == "episode" %}
+    {% if include.source.audio_duration %}
+      <span class="font-size-smallest">{{ include.source.audio_duration }} min</span>
+    {% endif %}
   {% endif %}
 
   <svg class="icon" viewBox="0 0 256 256">

--- a/_includes/_media-label.html
+++ b/_includes/_media-label.html
@@ -14,10 +14,8 @@
     {% endif %}
   {% elsif content_type == "video" or content_type == "message" %}
     {% if include.source.video_duration %}<span class="font-size-smallest">{{ include.source.video_duration }}</span>{% endif %}
-  {% elsif content_type == "song" %}
+  {% elsif content_type == "song" or content_type == "episode" %}
     {% if include.source.audio_duration %}<span class="font-size-smallest">{{ include.source.audio_duration }}</span>{% endif %}
-  {% elsif content_type == "episode" %}
-    {% if include.source.audio_duration %}<span class="font-size-smallest">{{ include.source.audio_duration }} min listen</span>{% endif %}
   {% endif %}
 
   <svg class="icon" viewBox="0 0 256 256">

--- a/_includes/_media-label.html
+++ b/_includes/_media-label.html
@@ -12,8 +12,10 @@
     {% if read_time > 0 %}
       <span class="font-size-smallest">{{ read_time }} min read</span>
     {% endif %}
-  {% else %}
-    <span class="font-size-smallest">{{ include.source.duration }}</span>
+  {% elsif content_type == "video" or content_type == "message" %}
+    {% if include.source.video_duration %}<span class="font-size-smallest">{{ include.source.video_duration }} min watch</span>{% endif %}
+  {% elsif content_type == "song" or content_type == "episode" %}
+    {% if include.source.audio_duration %}<span class="font-size-smallest">{{ include.source.audio_duration }} min listen</span>{% endif %}
   {% endif %}
 
   <svg class="icon" viewBox="0 0 256 256">


### PR DESCRIPTION
### Problem
Messages not receiving an icon on the homepage.

### Solution
Add messages to the media label partial.

### Testing
Visit the home page and see if recent media cards (specifically messages) have an icon on them.

**Bonus fix:** I also fixed the duration logic. Looks like the content model changed since this partial was written, media types either have a `audio_duration` or `video_duration` field and not a `duration` field. I assume this was to account for media types with both? I didn't see this on Contentful, but could've missed it. 

Also added the "min watch/listen" text to the div to match the style of articles. I don't know if this was how it originally looked but some of the cards looked strange with a single number just kinda hanging out there.