### PR TITLE
DE6065 - perspective bg img

### DIFF
--- a/_assets/stylesheets/pages/_perspectives.scss
+++ b/_assets/stylesheets/pages/_perspectives.scss
@@ -168,6 +168,7 @@
   }
 
   .perspective-set {
+    background-color: $cr-blue;
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;

--- a/_config.yml
+++ b/_config.yml
@@ -193,6 +193,7 @@ assets:
   - _assets/javascripts
 
 imgix_params:
+  overlay_50: "blend64=MTUxNTE1&balph=50&bm=normal"
   placeholder: "auto=format,compress&w=10"
   placeholder_card: "auto=format,compress&w=12&h=9&fit=crop"
   placeholder_square: "auto=format,compress&w=10&h=10&fit=crop"

--- a/_includes/_perspective_set.html
+++ b/_includes/_perspective_set.html
@@ -1,4 +1,4 @@
-<div class="perspective-set" style="background-image: url('{{ include.set.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}');" data-optimize-bg-img>
+<div class="perspective-set"{% if include.set.image.url %} style="background-image: url('{{ include.set.image.url | imgix: site.imgix }}?{{ site.imgix_params.placeholder }}?{{ site.imgix_params.overlay_50 }}');" data-optimize-bg-img{% endif %}>
   <div class="container">
     <div class="row">
       <main class="related-articles">


### PR DESCRIPTION
### Problem
Perspective sets look bad without a background image.

### Solution
Background image of perspective sets should be required and all background images should have an overlay. As a precaution, adding a default background color if a perspective set makes it through without an image.