### PR TITLE
DE6073 - Current series logic

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,7 +100,7 @@ contentful:
       series: videos
   series:
     map:
-      date: starts_at
+      date: published_at
   song:
     map:
       date: published_at


### PR DESCRIPTION
## Problem
Current series is defined by when it starts rather than when it's published. This creates an issue where upcoming series aren't publicized before they begin.

## Solution
Change series sort to `published_at` instead of `starts_at`. Checked with BSO and they say this doesn't impact them.

## Testing
Check /series and media landing (series section) to make sure the most recently published series shows first.