### PR TITLE
DE5855 Customizeable Index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,10 @@ group :jekyll_plugins do
   gem 'jekyll-redirect-from'
   gem 'jekyll-feed', '~> 0.6'
   gem 'jekyll-crds', git: 'https://github.com/crdschurch/jekyll-crds.git', tag: '0.0.1'
-  gem "jekyll-cloudsearch", git: 'https://github.com/crdschurch/jekyll-cloudsearch', tag: '0.0.5'
+
+  gem "jekyll-cloudsearch", git: 'https://github.com/crdschurch/jekyll-cloudsearch', tag: '0.1.0'
+  #gem 'jekyll-cloudsearch', path: File.expand_path('../jekyll-cloudsearch', __dir__)
+
   gem 'jekyll-placeholders', '~> 0.0', git: 'https://github.com/ample/jekyll-placeholders.git'
   gem 'jekyll-coffeescript'
   gem 'paging-mister-hyde', '~> 0.2', git: 'https://github.com/ample/paging-mister-hyde.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,10 +37,11 @@ GIT
 
 GIT
   remote: https://github.com/crdschurch/jekyll-cloudsearch
-  revision: fee0f94b3f19b005d433e6a804cfcede6188bf30
-  tag: 0.0.5
+  revision: 18aae390f519c00a18e75ab4cb2a3a0c50f77163
+  tag: 0.1.0
   specs:
-    jekyll-cloudsearch (0.0.5)
+    jekyll-cloudsearch (0.1.0)
+      activesupport
       aws-sdk-cloudsearchdomain
       contentful-management (~> 1.10.1)
       jekyll
@@ -75,11 +76,11 @@ GEM
     autoprefixer-rails (9.3.1)
       execjs
     aws-eventstream (1.0.1)
-    aws-partitions (1.110.0)
+    aws-partitions (1.113.0)
     aws-sdk-cloudsearchdomain (1.5.0)
       aws-sdk-core (~> 3, >= 3.26.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-core (3.37.0)
+    aws-sdk-core (3.38.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -290,4 +291,4 @@ DEPENDENCIES
   video-tags (~> 0.0.1)!
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/_config.yml
+++ b/_config.yml
@@ -220,3 +220,8 @@ image_sizes:
   topic_feature_sub: "(min-width: 992px) 370px, (min-width: 0px) 100px"
 
 typekit_url: https://use.typekit.net/ccb3vpa.css
+
+cloudsearch:
+  article:
+    - body
+    - lead_text


### PR DESCRIPTION
## Problem
Lead text part of the article not being indexed for search

## Solution
Bump `jekyll-cloudsearch` to latest version, configure articles to index `lead_text` in addition to `body` content

## Testing
To see this in action, use the normal search tool on [int.crossroads.net](https://int.crossroads.net/search) and search for some unique piece of content that is contained solely within the `lead_text` attribute of some article in Contentful. For example... 

https://app.contentful.com/spaces/p9oq1ve41d7r/entries/4egpBxzcwEq4goimw8wm0A

...contains "Mommy" in the `lead_text` field, so you should see it returned here: 

https://int.crossroads.net/search?type=media&q=Mommy