### PR TITLE
Feature/us15748 message bg image

### DIFF
--- a/_includes/_overlay-card.html
+++ b/_includes/_overlay-card.html
@@ -1,9 +1,20 @@
+{% comment %}
+// This assures the messages content type uses the background image instead of the thumbnail image like all other content types.
+{% endcomment %}
+{% assign handle = item.content_type %}
+{% case handle %}
+  {% when 'message' %}
+    {% assign image_source = item.background_image.url %}
+  {% when 'episode' %}
+    {% assign image_source = item.podcast.image.url %}
+  {% else %}
+    {% assign image_source = item.image.url %}
+{% endcase %}
+
 <a href="{{ item.url }}" class="overlay-card{% if include.size == 'xl' %} overlay-card-xl{% endif %}">
   <div class="bg-overlay"></div>
   <div class="overlay-card-image">
-    {% assign image = item.image %}
-    {% if item.content_type == 'episode' %}{% assign image = item.podcast.image %}{% endif %}
-    <img src="{% if image.url %}{{ image.url | imgix: site.imgix }}{% else %}{{ site.default_image | imgix: site.imgix }}{% endif %}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{% if include.size == 'xl' %}{{ site.image_sizes.full_width }}{% else %}{{ site.image_sizes.card_2x }}{% endif %}" alt="{{ image.title }}" data-optimize-img>
+    <img src="{% if image_source %}{{ image_source | imgix: site.imgix }}{% else %}{{ site.default_image | imgix: site.imgix }}{% endif %}?{{ site.imgix_params.placeholder_sixteen_nine }}" sizes="{% if include.size == 'xl' %}{{ site.image_sizes.full_width }}{% else %}{{ site.image_sizes.card_2x }}{% endif %}" alt="{{ image_source.title }}" data-optimize-img>
   </div>
 
   <div class="overlay-card-content">

--- a/_includes/_overlay-feature-card.html
+++ b/_includes/_overlay-feature-card.html
@@ -1,15 +1,17 @@
 
 {% comment %}
-// This assures the songs content type uses the background image instead of the thumbnail image like all other content types.
+// This assures the songs and messages content types use the background image instead of the thumbnail image like all other content types.
 {% endcomment %}
 {% assign handle = item.content_type %}
 {% case handle %}
   {% when 'song' %}
-     {% assign image_source = item.bg_image.url %}
+    {% assign image_source = item.bg_image.url %}
+  {% when 'message' %}
+    {% assign image_source = item.background_image.url %}
   {% when 'episode' %}
-     {% assign image_source = item.podcast.image.url %}
+    {% assign image_source = item.podcast.image.url %}
   {% else %}
-     {% assign image_source = item.image.url %}
+    {% assign image_source = item.image.url %}
 {% endcase %}
 
 <a href="{{ item.url }}" class="overlay-feature-card-link">


### PR DESCRIPTION
## Problem
The background image for messages looks bad when used with the overlay style of card, i.e., cards where the text overlays on top of an image.

## Solution
On the featured overlay (jumbotron on homepage), I added messages to the switch statement. On the other overlay partial, I replicated the switch statement logic. In both partials, messages should now use the images saved to the `background_image` fields as their background images.

**Note:**
The songs media type was excluded from the generic overlay partial as requested by Becky. She said songs are behaving as expected and this fix should only apply to messages.

## Testing
Overlay cards exist on media home, /topics/topic-name, /tags/tag-name, /articles.

With exceptions to the homepage, I don't believe the messages media type appear on these pages. Since I modified a partial, it's good to test for possible regressions.