### PR TITLE
Defect/de6173 fix topics on episode pages

### DIFF
--- a/_includes/_media-card.html
+++ b/_includes/_media-card.html
@@ -1,5 +1,4 @@
 {% assign author = site.authors | where: "name", card.author | first %}
-{% assign topic = site.topics | where: "title", card.topic | first %}
 
 {% if include.carousel == true %}
 <div class="card carousel-cell card-2x">

--- a/_includes/_topic.html
+++ b/_includes/_topic.html
@@ -1,0 +1,10 @@
+{% if topic %}
+<p class="flush-bottom soft-top">
+  <strong>Topic</strong>
+</p>
+<ul class="list-inline">
+  <li>
+    <a href="{{ topic.url }}">{{ topic.title }}</a>
+  </li>
+</ul>
+{% endif %}

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -62,18 +62,9 @@ title: Articles
         </div>
 
         <!-- Topic -->
-        {% if topic %}
-          <div class="keywords">
-            <p class="flush-bottom soft-top">
-              <strong>Topic</strong>
-            </p>
-            <ul class="list-inline">
-              <li>
-                <a href="{{ topic.url }}">{{ topic.title }}</a>
-              </li>
-            </ul>
-          </div>
-        {% endif %}
+        <div class="keywords">
+          {% include _topic.html %}
+        </div>
 
         <!-- Tags -->
         {% include _tags_list.html tags=page.tags %}

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -64,8 +64,8 @@ layout: default
         </div>
 
         <!-- Topic -->
-        {% assign topic = site.topics | where: "title", page.topic | first %}
-        {% if page.topic %}
+        {% assign topic = page.category | get_doc %}
+        {% if topic %}
         <p class="flush-bottom soft-top">
           <strong>Topic</strong>
         </p>

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -65,16 +65,7 @@ layout: default
 
         <!-- Topic -->
         {% assign topic = page.category | get_doc %}
-        {% if topic %}
-        <p class="flush-bottom soft-top">
-          <strong>Topic</strong>
-        </p>
-        <ul class="list-inline">
-          <li>
-            <a href="{{ topic.url }}">{{ topic.title }}</a>
-          </li>
-        </ul>
-        {% endif %}
+        {% include _topic.html %}
 
         <!-- Tags -->
         {% include _tags_list.html tags=page.tags %}

--- a/_layouts/message.html
+++ b/_layouts/message.html
@@ -94,17 +94,8 @@ layout: default
             </div>
 
             <!-- Only 1 topic per page -->
-            {% if page.category %}
-              {% assign topic = site.categories | where: 'slug', page.category.slug | first %}
-              <p class="flush-bottom soft-top">
-                <strong>Topic</strong>
-              </p>
-              <ul class="list-inline">
-                <li>
-                  <a href="{{ topic.url }}">{{ topic.title }}</a>
-                </li>
-              </ul>
-            {% endif %}
+            {% assign topic = site.categories | where: 'slug', page.category.slug | first %}
+            {% include _topic.html %}
 
             <!-- Page can have many tags -->
             {% include _tags_list.html tags=page.tags %}

--- a/_layouts/song.html
+++ b/_layouts/song.html
@@ -110,16 +110,7 @@ layout: default
 
       <!-- Topic -->
       {% assign topic = page.category | get_doc %}
-      {% if topic %}
-        <p class="flush-bottom soft-top">
-          <strong>Topic</strong>
-        </p>
-        <ul class="list-inline">
-          <li>
-            <a href="{{ topic.url }}">{{ topic.title }}</a>
-          </li>
-        </ul>
-      {% endif %}
+      {% include _topic.html %}
 
       <!-- Tags -->
       {% include _tags_list.html tags=page.tags %}

--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -72,17 +72,8 @@ layout: default
             </div>
 
             <!-- Only 1 topic per page -->
-            {% if page.category %}
-              {% assign topic = site.categories | where: 'slug', page.category.slug | first %}
-              <p class="flush-bottom soft-top">
-                <strong>Topic</strong>
-              </p>
-              <ul class="list-inline">
-                <li>
-                  <a href="{{ topic.url }}">{{ topic.title }}</a>
-                </li>
-              </ul>
-            {% endif %}
+            {% assign topic = site.categories | where: 'slug', page.category.slug | first %}
+            {% include _topic.html %}
 
             <!-- Page can have many tags -->
             {% include _tags_list.html tags=page.tags %}


### PR DESCRIPTION
## Problem
Episodes aren't displaying a topic/category

## Solution
Fix topic assign logic and dry up topics code by moving it to a partial

### Corresponding Branch
n/a

## Testing
This story affects: Articles, Episodes, Messages, Songs, Videos

There should be no regression for Articles, Messages, Songs, or Videos:
https://mediaint.crossroads.net/articles/monetate-cta-test
https://mediaint.crossroads.net/series/spark-2018/week-1-how-do-we-think-about-depression
https://mediaint.crossroads.net/songs/anybody-else
https://mediaint.crossroads.net/videos/tristique-bibendum-ornare-nullam

Topics should now show again on Episodes:
https://mediaint.crossroads.net/podcasts/ikr/episode-03-01
