### PR TITLE
Feature/us15754 monetate product api

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -38,23 +38,23 @@
   <meta name="twitter:site" content="@crdschurch">
 
   <script>
-    var CRDS = window.CRDS || {};
+  var CRDS = window.CRDS || {};
 
-    CRDS.media = {
-      cms: '{{ site.shared_header.cms }}',
-      app: '{{ site.shared_header.app }}',
-      img: '{{ site.shared_header.img }}',
-      prefix: '{{ site.shared_header.prefix }}'
-    }
+  CRDS.media = {
+    cms: '{{ site.shared_header.cms }}',
+    app: '{{ site.shared_header.app }}',
+    img: '{{ site.shared_header.img }}',
+    prefix: '{{ site.shared_header.prefix }}'
+  }
 
-    CRDS.rollCall = {
-      formUrl: '{{ site.ENV.ROLL_CALL_FORM_URL }}',
-      totalFieldId: '{{ site.ENV.ROLL_CALL_TOTAL_FIELD_ID }}',
-      urlFieldId: '{{ site.ENV.ROLL_CALL_URL_FIELD_ID }}'
-    }
+  CRDS.rollCall = {
+    formUrl: '{{ site.ENV.ROLL_CALL_FORM_URL }}',
+    totalFieldId: '{{ site.ENV.ROLL_CALL_TOTAL_FIELD_ID }}',
+    urlFieldId: '{{ site.ENV.ROLL_CALL_URL_FIELD_ID }}'
+  }
 
-    var JEKYLL_ENV = '{{ site.jekyll_env }}';
-    </script>
+  var JEKYLL_ENV = '{{ site.jekyll_env }}';
+  </script>
 
 {% include _gtm.html %}
 {% include _monetate-head.html %}

--- a/_includes/_monetate-body.html
+++ b/_includes/_monetate-body.html
@@ -1,4 +1,14 @@
 <!-- send data to Monetate -->
+{% if page.content_type contains 'article'
+or page.content_type contains 'episode'
+or page.content_type contains 'message'
+or page.content_type contains 'perspectives'
+or page.content_type contains 'podcast'
+or page.content_type contains 'series'
+or page.content_type contains 'song'
+or page.content_type contains 'video'
+or page.content_type == 'category' %}
 <script>
   window.monetateQ.push(["trackData"]);
 </script>
+{% endif %}

--- a/_includes/_monetate-head.html
+++ b/_includes/_monetate-head.html
@@ -9,15 +9,29 @@
 <script>
   window.monetateQ = window.monetateQ || [];
   window.monetateQ.push(["setPageType", "product"]);
-  window.monetateQ.push([
-    "addCategories", [{% if page.category.size > 0 %}"{{ page.category.title | truncate: 128 | asciify }}",{% endif %}
-      {% if page.tags.size > 0 %} {% for tag in page.tags %}
-        "{{ tag.title | truncate: 128 | asciify }}",
-      {% endfor %} {% endif %}
-      ]
-  ]);
-
+  window.monetateQ.push(["addProductDetails",
+    ["{{ page.contentful_id }}"]]);
 </script>
 {% endif %}
 
-<!-- articles  episodes messages perspectives podcasts series songs videos -->
+{% if page.content_type == 'category' %}
+<script>
+  window.monetateQ = window.monetateQ || [];
+  window.monetateQ.push(["setPageType", "topic"]);
+  window.monetateQ.push([
+    "addCategories", ["{{ page.title | truncate: 128 | asciify }}"]
+  ]);
+  window.monetateQ.push([
+    "addProducts", [
+      {% for item in page.featured_media %}
+      "{{ item.contentful_id }}",
+      {% endfor %}
+      {% for data in page.featured_tag_data %}
+      {% assign media_items = data.media %}
+        {% for item in media_items %}
+        "{{ item.contentful_id }}",
+        {% endfor %}
+      {% endfor %}
+    ]]);
+</script>
+{% endif %}


### PR DESCRIPTION
## Problem
Targeting based on the product category does not work as expected 
Setting the Page Category did not solve the problem

## Solution
Remove the category from product pages and add product ID instead. 
Adds page type, category and product IDs for Topic pages

### Corresponding Branch
No corresponding PRs

## Testing
Unfortunately, Monetate is tied to the URL, so we won't be able to tell definitively if this solves the problem until the code is merged in int.

On int and local builds, you can tell the Monetate API calls are working correctly by using the Monetate Inspector tool. Unfortunately, this tool does not work in the deploy preview.

In order to install the inspector tool:

> Open the Inspector [Install Page](https://marketer.monetate.net/site_media/static/inspector/install.html) in every browser that you use for testing. Once the page loads, drag the “Inspector” button to your Bookmarks Bar. Inspector is now installed.
> 
> Navigate to your site and then press the link in your Bookmarks Bar to show the Monetate Inspector.

You will need to be logged into Monetate for the inspector tool to work

_**For Monetate all topics/categories/tags are Categories**_

You should see the following:
On /articles/monetate-cta-test The Page Type is product and the Category is Culture
Once it's merged, there should be a CTA template above Recent Articles on https://mediaint.crossroads.net/articles/monetate-cta-test

On /videos/tristique-bibendum-ornare-nullam The Page Type is product and the Categories are Finance, murray, Faith