### PR TITLE
US14301 - YT click events

### DIFF
--- a/_assets/javascripts/components/yt-event-handler.js
+++ b/_assets/javascripts/components/yt-event-handler.js
@@ -28,15 +28,26 @@
     }
 
     function onPlayerStateChange(event) {
-      if (typeof analytics !== 'undefined') {
-        analytics.track('Media Video Details', {
-          Title: this.player.getVideoData().title,
-          VideoId: this.player.getVideoData().video_id,
-          Source: window.location.href,
-          VideoTotalDuration: this.player.getDuration(),
-          CurrentTime: this.player.getCurrentTime(),
-          ReasonForEnding: videoStopped(event)
-        });
+      if (event.data == YT.PlayerState.ENDED || event.data == YT.PlayerState.PAUSED) {
+        if (typeof analytics !== 'undefined') {
+          analytics.track('VideoEnded', {
+            Title: this.player.getVideoData().title,
+            VideoId: this.player.getVideoData().video_id,
+            Source: 'CrossroadsNet',
+            VideoTotalDuration: this.player.getDuration(),
+            CurrentTime: this.player.getCurrentTime(),
+            ReasonForEnding: videoStopped(event)
+          });
+        }
+      } else {
+        if (typeof analytics !== 'undefined') {
+          analytics.track('VideoStarted', {
+            Title: this.player.getVideoData().title,
+            VideoId: this.player.getVideoData().video_id,
+            Source: 'CrossroadsNet',
+            VideoTotalDuration: this.player.getDuration()
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem
Brian Painter requested changes to the way YT click events are being handled. His requests:
- Split the events into two functions
- Both functions should be labeled as directed in the story
- `Source` should have a property of 'CrossroadsNet' (this field exists to tell him if the info is coming from the mobile app or the website)

## Solution
Added some conditional logic to the player's state change function; if a video ends or is paused it kicks off the `VideoEnded` event, every other state change kicks off the `VideoStarted` event.

## Testing
I'm unsure how to test this locally. Before, because all state changes fell under the same tracker, I knew it was working when playing a video returned `ReasonForEnding: null` in the console. Since this logic was removed, there shouldn't be anything in the console. 

Locally, I tested my conditional logic with `console.log` to make sure the correct info was being sent at the right state change. Since this was the only real code change I've made to this file, I have no reason to believe it breaks it.