### PR TITLE
US13615 - Listen to Audio

### DIFF
--- a/_assets/javascripts/components/audio_video_toggler.js
+++ b/_assets/javascripts/components/audio_video_toggler.js
@@ -1,0 +1,52 @@
+class AudioVideoTrigger {
+
+  constructor() {
+    this.initEls();
+    this.initVisibility();
+    this.listen();
+  }
+
+  initEls() {
+    this.playerContainer = $('[data-audio-video-control]').first();
+    this.audioTrigger = $('[data-audio-trigger]').first();
+    this.audioPlayer = $('[data-audio-player]').first();
+    if (this.audioPlayer.length > 0) this.audioHTML = this.audioPlayer[0].outerHTML;
+    this.videoTrigger = $('[data-video-trigger]').first();
+    this.videoPlayer = $('[data-video-player]').first();
+    if (this.videoPlayer.length > 0) this.videoHTML = this.videoPlayer[0].outerHTML;
+  }
+
+  initVisibility() {
+    this.playerContainer.html('');
+    this.playerContainer.removeClass('hide');
+    if (this.videoPlayer.length > 0) {
+      this.playerContainer.html(this.videoHTML);
+      this.audioTrigger.removeClass('hide');
+      this.videoTrigger.addClass('hide');
+    } else {
+      this.playerContainer.html(this.audioHTML);
+      this.audioTrigger.remove();
+    }
+  }
+
+  listen() {
+    this.audioTrigger.on('click', (event) => this.activateAudio());
+    this.videoTrigger.on('click', (event) => this.activateVideo());
+  }
+
+  activateAudio() {
+    this.playerContainer.html(this.audioHTML);
+    this.audioTrigger.addClass('hide');
+    this.videoTrigger.removeClass('hide');
+  }
+
+  activateVideo() {
+    this.playerContainer.html(this.videoHTML);
+    this.audioTrigger.removeClass('hide');
+    this.videoTrigger.addClass('hide');
+  }
+}
+
+$(document).ready(function() {
+  if ($('[data-audio-trigger]').length > 0) new AudioVideoTrigger;
+});

--- a/_assets/javascripts/config.js
+++ b/_assets/javascripts/config.js
@@ -24,6 +24,7 @@ module.exports = [
       'vendor/crds-status-message-v0.1.3.min'
     ],
     files: [
+      'components/audio_video_toggler',
       'components/clipboard',
       'components/header',
       'components/images',

--- a/_includes/_yt-embed.html
+++ b/_includes/_yt-embed.html
@@ -1,4 +1,4 @@
-<div class="embed-responsive embed-responsive-16by9">
+<div class="embed-responsive embed-responsive-16by9" data-video-player>
   <iframe id="js-media-video"
           width="560"
           height="315"

--- a/_layouts/message.html
+++ b/_layouts/message.html
@@ -8,19 +8,32 @@ layout: default
       <div class="row">
         <div class="col-md-10 col-md-offset-1">
 
-          {% if page.source_url %}
-          <div class="push-top soft-top">
-            <div class="mobile-flush">
-              <!-- Needed for YT partial to load video -->
-              {% assign video_id = page.source_url | youtube_id %}
-              {% include _yt-embed.html %}
+          {% if page.source_url or page.audio_source_url %}
+            <div class="push-top soft-top">
+              <div class="mobile-flush">
+                {% comment %} audio_video_toggler.js handles switching between video and audio. {% endcomment %}
+                <div class="embed-responsive embed-responsive-16by9 hide" data-audio-video-control>
+                  {% if page.source_url %}
+                    {% assign video_id = page.source_url | youtube_id %}
+                    <iframe id="js-media-video" width="560" height="315" src="https://www.youtube.com/embed/{{ video_id }}?enablejsapi=1&rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen data-video-player></iframe>
+                  {% endif %}
+                  {% if page.audio_source_url %}
+                    <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url={{ page.audio_source_url }}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true" data-audio-player></iframe>
+                  {% endif %}
+                </div>
+              </div>
             </div>
-          </div>
           {% endif %}
 
           <header>
-            {% if page.audio_file.url or page.video_file.url or page.program.url %}
+            {% if page.audio_file.url or page.video_file.url or page.program.url or page.audio_source_url %}
             <div class="sources push-quarter-top">
+              {% if page.source_url %}
+              <a class="secondary hide" href="javascript:void(0)" data-video-trigger>Watch video</a>
+              {% endif %}
+              {% if page.audio_source_url %}
+              <a class="secondary hide" href="javascript:void(0)" data-audio-trigger>Listen to audio</a>
+              {% endif %}
               {% if page.audio_file.url %}
               <a class="secondary" href="{{ page.audio_file.url | imgix: site.imgix }}?dl={{ page.audio_file.url | split: '/' | last }}">Download audio</a>
               {% endif %}


### PR DESCRIPTION
Add an embedded Soundcloud player that shows conditionally.

This is supposed to be hotfixed into production. This is #482. I figured we could test here first prior to merging into master.

Pages to test:
- Has both, that should toggle: https://deploy-preview-481--crds-mediaint.netlify.com/series/the-new-mind-int-just-for-you/the-new-mind-week-1-the-three-m's-of-the-mind
- Has only audio: https://deploy-preview-481--crds-mediaint.netlify.com/series/id/id-theft
- Has none: https://deploy-preview-481--crds-mediaint.netlify.com/series/dollars-sense-and-sensibility/money-myths