### PR TITLE
DE6295 Series Redirect Error

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1481,7 +1481,6 @@
 /series/97/* /series/an-unexpected-interruption-of-scandalous-love 302
 /series/98/* /series/full-contact-life 302
 /series/99/* /series/id 302
-/series/* /series 302
 /tags /topics 302
 /videos/tags  /videos 302
 /*  /404/index.html 404


### PR DESCRIPTION
## Problem
https://media.crossroads.net/series/* doesn't go to the coffee cup page like the redirect rule specifies

## Solution
The rule `/series/* /series 302` is redundant and covered by `/*  /404/index.html 404`

## Testing
Go to any bogus url that starts with:
https://deploy-preview-486--crds-mediaint.netlify.com/series/
for example:
https://deploy-preview-486--crds-mediaint.netlify.com/series/asdf

They should redirect to the Crossroads branded 404 page with the coffee cup