### PR TITLE
DE6353 Related Articles When Tags Are Empty

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -100,7 +100,7 @@ get_doc %} {% assign tags = page.tags | get_doc %}
                   {% include _article-card.html %}
                 {% endfor %}
               {% else %}
-              {% assign recent = site.articles | sort: 'date' | reverse | slice: 0, 3 | exclude: page.title %}
+              {% assign recent = site.articles | sort: 'date' | reverse | slice: 0, 4 | exclude: page.title | limit: 3 %}
                 {% for post in recent %}
                   {% include _article-card.html %}
                 {% endfor %}

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -83,7 +83,8 @@ get_doc %} {% assign tags = page.tags | get_doc %}
 
         <section class="soft-top">
           <header class="more-media-header">
-            <h3>related articles</h3>
+            {% assign related = page | related: site %}
+            <h3>{% if related != blank %}related{% else %}recent{% endif %} articles</h3>
             <a class="font-size-small" href="/articles">See all articles</a>
           </header>
 
@@ -94,10 +95,16 @@ get_doc %} {% assign tags = page.tags | get_doc %}
               data-card-deck
             >
               <div class="feature-cards feature-cards-3x">
-                {% assign related = page | related: site %}
+              {% if related != blank %}
                 {% for post in related %}
                   {% include _article-card.html %}
                 {% endfor %}
+              {% else %}
+              {% assign recent = site.articles | sort: 'date' | reverse | slice: 0, 3 | exclude: page.title %}
+                {% for post in recent %}
+                  {% include _article-card.html %}
+                {% endfor %}
+              {% endif %}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Problem
When tags are empty on articles, no article cards display under related articles 
See [this article](https://mediaint.crossroads.net/articles/handling-depression-how-to-keep-getting-up-test) for an example

## Solution
Add fallback logic for recent articles if there are no tags

## Testing
https://deploy-preview-508--crds-mediaint.netlify.com/articles/handling-depression-how-to-keep-getting-up-test