### PR TITLE
US16401 - Filter Articles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,5 +55,6 @@ group :jekyll_plugins do
   gem 'jekyll-placeholders', '~> 0.0', git: 'https://github.com/ample/jekyll-placeholders.git'
   gem 'jekyll-coffeescript'
   gem 'paging-mister-hyde', '~> 0.2', git: 'https://github.com/ample/paging-mister-hyde.git'
+  gem 'article-tags', '~> 0.0.1', path: File.expand_path('./vendor/gems/article-tags', __dir__)
   gem 'video-tags', '~> 0.0.1', path: File.expand_path('./vendor/gems/video-tags', __dir__)
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,12 @@ GIT
       jekyll
 
 PATH
+  remote: vendor/gems/article-tags
+  specs:
+    article-tags (0.0.1)
+      jekyll
+
+PATH
   remote: vendor/gems/video-tags
   specs:
     video-tags (0.0.1)
@@ -248,6 +254,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  article-tags (~> 0.0.1)!
   dotenv
   guard-rspec
   hashie
@@ -274,4 +281,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,4 +281,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.0.1
+   1.17.3

--- a/_includes/_article_filters.html
+++ b/_includes/_article_filters.html
@@ -1,0 +1,13 @@
+<ul>
+  <li><a href="/articles" class="{% if page.url == '/articles/' %}active{% endif %}">Most Recent</a></li>
+  {% assign filters = site.article_filters | group_by: "category_title" | sort: "name" %}
+  {% for filter in filters %}
+    <li>{{ filter.name }}</li>
+    <ul>
+      {% for item in filter.items %}
+        {% assign item_url = item.url | append: '/index.html' %}
+        <li><a href="{{ item.url }}" class="{% if page.url == item_url %}active{% endif %}">{{ item.title }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
+</ul>

--- a/_includes/_article_index.html
+++ b/_includes/_article_index.html
@@ -1,0 +1,17 @@
+<div data-page="articles">
+  <div class="row" data-page-number="{{ page.articles.page }}">
+    {% for item in page.articles.docs %}
+    <div class="col-sm-6 push-bottom">
+      {% include _overlay-card.html collection="articles" %}
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="loading hide">
+    {% include _preloader.html %}
+  </div>
+</div>
+
+<div class="push-top">
+  {% include _pagination.html collection="articles" remote=true label="" %}
+</div>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -3,8 +3,9 @@ layout: default
 title: Articles
 ---
 
-{% assign author = page.author | get_doc %} {% assign topic = page.category |
-get_doc %} {% assign tags = page.tags | get_doc %}
+{% assign author = page.author | get_doc %}
+{% assign topic = page.category | get_doc %}
+{% assign tags = page.tags | get_doc %}
 
 <article class="article-tpl">
   <header

--- a/_layouts/article_filter.html
+++ b/_layouts/article_filter.html
@@ -9,32 +9,14 @@ paginate:
 ---
 
 <div class="container">
-
-  Hello World
-
-  {% comment %} <ol class="breadcrumb hard-sides hard-bottom push-top flush-bottom">
+  <ol class="breadcrumb hard-sides hard-bottom push-top">
     <li><a href="/">Media</a></li>
-    <li><a href="/videos">Videos</a></li>
+    <li><a href="/articles">Articles</a></li>
   </ol>
 
   <h1 class="font-family-condensed-extra text-uppercase flush-top push-bottom">{{ page.title }}</h1>
-  <div class="row">
-    <div class="col-md-2 text-left">
-      {% include _video-nav.html %}
-    </div>
-    <div class="col-md-10">
-      <div class="cards-4x cards-2x-xs" data-page="videos">
-        <div class="row" data-page-number="{{ page.videos.page }}">
-          {% for video in page.videos.docs %}
-            {% include _video-card.html image_size="4x" %}
-          {% endfor %}
-        </div>
-        <div class="loading hide">
-          {% include _preloader.html %}
-        </div>
-      </div>
-      {% assign link_root = "videos/tags/" | append: page.slug %}
-      {% include _pagination.html collection="videos" remote=true %}
-    </div>
-  </div> {% endcomment %}
+
+  {% include _article_filters.html %}
+
+  {% include _article_index.html %}
 </div>

--- a/_layouts/article_filter.html
+++ b/_layouts/article_filter.html
@@ -1,7 +1,7 @@
 ---
 paginate:
   articles:
-    per: 8
+    per: 10
     sort: published_at desc
     where:
       tags.slug: :tag_slug

--- a/_layouts/article_filter.html
+++ b/_layouts/article_filter.html
@@ -5,7 +5,7 @@ paginate:
     sort: published_at desc
     where:
       tags.slug: :tag_slug
-      category.slug: category_slug
+      category.slug: :category_slug
 ---
 
 <div class="container">

--- a/_layouts/article_filter.html
+++ b/_layouts/article_filter.html
@@ -1,0 +1,40 @@
+---
+paginate:
+  articles:
+    per: 8
+    sort: published_at desc
+    where:
+      tags.slug: :tag_slug
+      category.slug: category_slug
+---
+
+<div class="container">
+
+  Hello World
+
+  {% comment %} <ol class="breadcrumb hard-sides hard-bottom push-top flush-bottom">
+    <li><a href="/">Media</a></li>
+    <li><a href="/videos">Videos</a></li>
+  </ol>
+
+  <h1 class="font-family-condensed-extra text-uppercase flush-top push-bottom">{{ page.title }}</h1>
+  <div class="row">
+    <div class="col-md-2 text-left">
+      {% include _video-nav.html %}
+    </div>
+    <div class="col-md-10">
+      <div class="cards-4x cards-2x-xs" data-page="videos">
+        <div class="row" data-page-number="{{ page.videos.page }}">
+          {% for video in page.videos.docs %}
+            {% include _video-card.html image_size="4x" %}
+          {% endfor %}
+        </div>
+        <div class="loading hide">
+          {% include _preloader.html %}
+        </div>
+      </div>
+      {% assign link_root = "videos/tags/" | append: page.slug %}
+      {% include _pagination.html collection="videos" remote=true %}
+    </div>
+  </div> {% endcomment %}
+</div>

--- a/_redirects
+++ b/_redirects
@@ -28,6 +28,7 @@
 /articles/2018-04-25-hey-gq-stay-in-your-lane /articles/hey-gq-stay-in-your-lane  301
 /articles/2018-04-26-how-a-hooker-and-her-lies-pleased-god  /articles/how-a-hooker-and-her-lies-pleased-god 301
 /articles/2018-04-26-schoolhouse-rock-bible-edition /articles/schoolhouse-rock-bible-edition  301
+/articles/filters /articles 302
 /episodes /podcasts 302
 /media/5780/* /songs/i-am-here-song-from-a-father 302
 /media/5781/* /songs/not-my-clothes 302

--- a/articles.html
+++ b/articles.html
@@ -14,21 +14,7 @@ paginate:
 
   <h1 class="font-family-condensed-extra text-uppercase flush-top push-bottom">Articles</h1>
 
-  <div data-page="articles">
-    <div class="row" data-page-number="{{ page.articles.page }}">
-      {% for item in page.articles.docs %}
-      <div class="col-sm-6 push-bottom">
-        {% include _overlay-card.html collection="articles" %}
-      </div>
-      {% endfor %}
-    </div>
+  {% include _article_filters.html %}
 
-    <div class="loading hide">
-      {% include _preloader.html %}
-    </div>
-  </div>
-
-  <div class="push-top">
-    {% include _pagination.html collection="articles" remote=true label="" %}
-  </div>
+  {% include _article_index.html %}
 </div>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'rspec'
 require 'jekyll'
 require 'jekyll-crds'
 require 'jekyll-placeholders'
+require 'article-tags'
 require 'video-tags'
 
 require 'pry'

--- a/vendor/gems/article-tags/article-tags.gemspec
+++ b/vendor/gems/article-tags/article-tags.gemspec
@@ -1,0 +1,16 @@
+lib = File.expand_path('./lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'article-tags/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'article-tags'
+  s.version     = Jekyll::ArticleTags::VERSION
+  s.licenses    = ['BSD-3']
+  s.summary     = "Dynamically builds pages for article tags"
+  s.authors     = ["Ample"]
+  s.email       = 'taylor@helloample.com'
+  s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.require_paths = ["lib"]
+
+  s.add_dependency 'jekyll'
+end

--- a/vendor/gems/article-tags/lib/article-tags.rb
+++ b/vendor/gems/article-tags/lib/article-tags.rb
@@ -1,0 +1,9 @@
+require 'jekyll'
+require 'article-tags/version'
+require 'article-tags/page_builder'
+require 'article-tags/generator'
+
+module Jekyll
+  module ArticleTags
+  end
+end

--- a/vendor/gems/article-tags/lib/article-tags/generator.rb
+++ b/vendor/gems/article-tags/lib/article-tags/generator.rb
@@ -1,0 +1,12 @@
+module Jekyll
+  module ArticleTags
+    class Generator < Jekyll::Generator
+      attr_accessor :site
+
+      def generate(site)
+        Jekyll::ArticleTags::PageBuilder.new(site)
+      end
+
+    end
+  end
+end

--- a/vendor/gems/article-tags/lib/article-tags/page_builder.rb
+++ b/vendor/gems/article-tags/lib/article-tags/page_builder.rb
@@ -31,15 +31,19 @@ module Jekyll
             site.config['article_filters'] = []
 
             tag_map.each do |map|
+              category = map[:category]
               map[:tags].each do |tag|
                 site.config['article_filters'] << {
                   'title' => tag['title'],
-                  'slug' => tag['slug'],
-                  'url' => "/articles/filters/#{map[:category]['slug']}+#{tag['slug']}"
+                  'slug' => "#{category['slug']}+#{tag['slug']}",
+                  'tag_title' => tag['title'],
+                  'tag_slug' => tag['slug'],
+                  'category_title' => category['title'],
+                  'category_slug' => category['slug'],
+                  'url' => "/articles/filters/#{category['slug']}+#{tag['slug']}"
                 }
               end
             end
-            binding.pry
           rescue NoMethodError => e
             site.config['article_filters'] = []
           end
@@ -48,15 +52,13 @@ module Jekyll
         def generate_pages
           # For each article tag, build out a corresponding page using the article_tag
           # layout.
-          featureable_tags.each do |tag|
-            page = Jekyll::Page.new(site, site.source, '_layouts', 'article_tag.html')
+          site.config['article_filters'].each do |tag|
+            page = Jekyll::Page.new(site, site.source, '_layouts', 'article_filter.html')
             # Customize the URL for the new page.
-            page.instance_variable_set('@url', "/articles/tags/#{tag.data['slug']}/index.html")
+            page.instance_variable_set('@url', "#{tag['url']}/index.html")
             # Add default frontmatter to the new page.
-            (page.data ||= {}).merge!(
-              'layout' => 'default',
-              'slug' => tag.data['slug'],
-              'title' => tag.data['title']
+            page.data = (page.data ||= {}).merge!(tag).merge!(
+              'layout' => 'default'
             )
             # Inject the page into the site's pages.
             site.pages << page

--- a/vendor/gems/article-tags/lib/article-tags/page_builder.rb
+++ b/vendor/gems/article-tags/lib/article-tags/page_builder.rb
@@ -1,0 +1,71 @@
+require 'fileutils'
+
+module Jekyll
+  module ArticleTags
+    class PageBuilder
+
+      attr_reader :site
+
+      def initialize(site)
+        @site = site
+        init_tags
+        generate_pages
+      end
+
+      private
+
+        def tags_from_articles_in_category(category_id)
+          site.collections['articles'].docs.select { |a| a.data.dig('category', 'id') == category_id }
+            .flat_map { |a| a.data['tags'] }.uniq
+        end
+
+        def init_tags
+          begin
+            tag_map = site.collections['categories'].docs.map { |category|
+              {
+                category: category.data,
+                tags: category.data['tags'] & tags_from_articles_in_category(category.data['id'])
+              }
+            }
+
+            site.config['article_filters'] = []
+
+            tag_map.each do |map|
+              map[:tags].each do |tag|
+                site.config['article_filters'] << {
+                  'title' => tag['title'],
+                  'slug' => tag['slug'],
+                  'url' => "/articles/filters/#{map[:category]['slug']}+#{tag['slug']}"
+                }
+              end
+            end
+            binding.pry
+          rescue NoMethodError => e
+            site.config['article_filters'] = []
+          end
+        end
+
+        def generate_pages
+          # For each article tag, build out a corresponding page using the article_tag
+          # layout.
+          featureable_tags.each do |tag|
+            page = Jekyll::Page.new(site, site.source, '_layouts', 'article_tag.html')
+            # Customize the URL for the new page.
+            page.instance_variable_set('@url', "/articles/tags/#{tag.data['slug']}/index.html")
+            # Add default frontmatter to the new page.
+            (page.data ||= {}).merge!(
+              'layout' => 'default',
+              'slug' => tag.data['slug'],
+              'title' => tag.data['title']
+            )
+            # Inject the page into the site's pages.
+            site.pages << page
+
+            # Run the paginator.
+            ::PagingMisterHyde::Paginator.new(site, page)
+          end
+        end
+
+    end
+  end
+end

--- a/vendor/gems/article-tags/lib/article-tags/version.rb
+++ b/vendor/gems/article-tags/lib/article-tags/version.rb
@@ -1,0 +1,5 @@
+module Jekyll
+  module ArticleTags
+    VERSION = "0.0.1"
+  end
+end

--- a/vendor/gems/article-tags/spec/support/collections/_articles/2019-02-02-article-a1-b1-x1.md
+++ b/vendor/gems/article-tags/spec/support/collections/_articles/2019-02-02-article-a1-b1-x1.md
@@ -1,0 +1,27 @@
+---
+id: article-a1-b1-x1
+contentful_id: article-a1-b1-x1
+content_type: article
+title: Article A1 B1 X1
+slug: article-a1-b1-x1
+published_at: '2019-02-01T00:00:00+00:00'
+date: '2019-02-01T00:00:00+00:00'
+category:
+  title: Category A
+  slug: cat-a
+  id: cat-a
+  content_type: category
+tags:
+- title: Tag A1
+  slug: tag-a1
+  id: tag-a1
+  content_type: tag
+- title: Tag B1
+  slug: tag-b1
+  id: tag-b1
+  content_type: tag
+- title: Tag X1
+  slug: tag-x1
+  id: tag-x1
+  content_type: tag
+---

--- a/vendor/gems/article-tags/spec/support/collections/_articles/2019-02-03-article-a1.md
+++ b/vendor/gems/article-tags/spec/support/collections/_articles/2019-02-03-article-a1.md
@@ -7,13 +7,13 @@ slug: article-a1
 published_at: '2019-02-01T00:00:00+00:00'
 date: '2019-02-01T00:00:00+00:00'
 category:
-  title: Category A
-  slug: cat-a
-  id: cat-a
+  title: Category B
+  slug: cat-b
+  id: cat-b
   content_type: category
 tags:
-- title: Tag A1
-  slug: tag-a1
-  id: tag-a1
+- title: Tag B2
+  slug: tag-b2
+  id: tag-b2
   content_type: tag
 ---

--- a/vendor/gems/article-tags/spec/support/collections/_articles/2019-02-03-article-a1.md
+++ b/vendor/gems/article-tags/spec/support/collections/_articles/2019-02-03-article-a1.md
@@ -1,0 +1,19 @@
+---
+id: article-a1
+contentful_id: article-a1
+content_type: article
+title: Article A1
+slug: article-a1
+published_at: '2019-02-01T00:00:00+00:00'
+date: '2019-02-01T00:00:00+00:00'
+category:
+  title: Category A
+  slug: cat-a
+  id: cat-a
+  content_type: category
+tags:
+- title: Tag A1
+  slug: tag-a1
+  id: tag-a1
+  content_type: tag
+---

--- a/vendor/gems/article-tags/spec/support/collections/_articles/2019-02-03-article-b2.md
+++ b/vendor/gems/article-tags/spec/support/collections/_articles/2019-02-03-article-b2.md
@@ -1,9 +1,9 @@
 ---
-id: article-a1
-contentful_id: article-a1
+id: article-b2
+contentful_id: article-b2
 content_type: article
-title: Article A1
-slug: article-a1
+title: Article B2
+slug: article-b2
 published_at: '2019-02-01T00:00:00+00:00'
 date: '2019-02-01T00:00:00+00:00'
 category:

--- a/vendor/gems/article-tags/spec/support/collections/_categories/cat-a.md
+++ b/vendor/gems/article-tags/spec/support/collections/_categories/cat-a.md
@@ -1,0 +1,10 @@
+---
+id: cat-a
+title: Category A
+slug: cat-a
+tags:
+  - title: Tag A1
+    slug: tag-a1
+    id: tag-a1
+    content_type: tag
+---

--- a/vendor/gems/article-tags/spec/support/collections/_categories/cat-b.md
+++ b/vendor/gems/article-tags/spec/support/collections/_categories/cat-b.md
@@ -1,0 +1,14 @@
+---
+id: cat-b
+title: Category B
+slug: cat-b
+tags:
+  - title: Tag B1
+    slug: tag-b1
+    id: tag-b1
+    content_type: tag
+  - title: Tag B2
+    slug: tag-b2
+    id: tag-b2
+    content_type: tag
+---

--- a/vendor/gems/article-tags/spec/support/collections/_categories/cat-c.md
+++ b/vendor/gems/article-tags/spec/support/collections/_categories/cat-c.md
@@ -1,0 +1,5 @@
+---
+id: cat-c
+title: Category C
+slug: cat-c
+---

--- a/vendor/gems/article-tags/spec/support/collections/_tags/tag-a1.md
+++ b/vendor/gems/article-tags/spec/support/collections/_tags/tag-a1.md
@@ -1,0 +1,8 @@
+---
+id: tag-a1
+contentful_id: tag-a1
+title: Tag A1
+slug: tag-a1
+content_type: tag
+---
+

--- a/vendor/gems/article-tags/spec/support/collections/_tags/tag-b1.md
+++ b/vendor/gems/article-tags/spec/support/collections/_tags/tag-b1.md
@@ -1,0 +1,8 @@
+---
+id: tag-b1
+contentful_id: tag-b1
+title: Tag B1
+slug: tag-b1
+content_type: tag
+---
+

--- a/vendor/gems/article-tags/spec/support/collections/_tags/tag-b2.md
+++ b/vendor/gems/article-tags/spec/support/collections/_tags/tag-b2.md
@@ -1,0 +1,8 @@
+---
+id: tag-b2
+contentful_id: tag-b2
+title: Tag B2
+slug: tag-b2
+content_type: tag
+---
+

--- a/vendor/gems/article-tags/spec/support/collections/_tags/tag-x1.md
+++ b/vendor/gems/article-tags/spec/support/collections/_tags/tag-x1.md
@@ -1,0 +1,8 @@
+---
+id: tag-x1
+contentful_id: tag-x1
+title: Tag X1
+slug: tag-x1
+content_type: tag
+---
+

--- a/vendor/gems/article-tags/spec/unit/generator_spec.rb
+++ b/vendor/gems/article-tags/spec/unit/generator_spec.rb
@@ -12,7 +12,10 @@ describe Jekyll::ArticleTags::Generator do
   end
 
   it 'should generate pages for article tags' do
-    urls = %w(/articles/tags/cat-a+tag-a1/index.html)
+    urls = %w(
+      /articles/filters/cat-a+tag-a1/index.html
+      /articles/filters/cat-b+tag-b2/index.html
+    )
     expect(@site.pages.collect(&:url)).to match_array(urls)
   end
 

--- a/vendor/gems/article-tags/spec/unit/generator_spec.rb
+++ b/vendor/gems/article-tags/spec/unit/generator_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Jekyll::ArticleTags::Generator do
+
+  before do
+    @site = JekyllHelper.scaffold(
+      collections_dir: File.expand_path('../support/collections', __dir__),
+      collections: %w(articles categories tags)
+    )
+    @generator = Jekyll::ArticleTags::Generator.new
+    @generator.generate(@site)
+  end
+
+  it 'should generate pages for article tags' do
+    urls = %w(/articles/tags/cat-a+tag-a1/index.html)
+    expect(@site.pages.collect(&:url)).to match_array(urls)
+  end
+
+end

--- a/vendor/gems/article-tags/spec/unit/page_builder_spec.rb
+++ b/vendor/gems/article-tags/spec/unit/page_builder_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Jekyll::ArticleTags::PageBuilder do
+
+  before do
+    @site = JekyllHelper.scaffold(
+      collections_dir: File.expand_path('../support/collections', __dir__),
+      collections: %w(articles categories tags)
+    )
+    @page_builder = Jekyll::ArticleTags::PageBuilder.new(@site)
+  end
+
+  it 'should build out an array of article categories and tags accessible to site config' do
+    exp_article_filters = [
+      {
+        "title" => "Category A",
+        "slug" => "cat-a",
+        "tags" => [
+          {
+            "title" => "Tag A1",
+            "slug" => "tag-a1",
+            "url" => "/articles/tags/cat-a+tag-a1"
+          }
+        ]
+      }
+    ]
+    expect(@site.config['article_filters']).to match_array(exp_article_filters)
+  end
+
+  it 'creates a page only for tags featured by a category' do
+    pending
+    raise "Create the page"
+
+    exp_page_data = ['Collection #1']
+    expect(@site.pages.collect { |p| p.data['title'] }).to match_array(exp_page_data)
+  end
+
+  it 'runs the paginator' do
+    pending
+    raise "Run the paginator"
+
+    exp_doc_titles = [["Powerhouse Trailer", "What's Crossroads?"]]
+    page_doc_titles = @site.pages.collect { |d| d.data['articles']['docs'].collect(&:title) }
+    expect(page_doc_titles).to match_array(exp_doc_titles)
+  end
+
+end

--- a/vendor/gems/article-tags/spec/unit/page_builder_spec.rb
+++ b/vendor/gems/article-tags/spec/unit/page_builder_spec.rb
@@ -40,8 +40,7 @@ describe Jekyll::ArticleTags::PageBuilder do
   end
 
   it 'runs the paginator' do
-    exp_doc_titles = [["Powerhouse Trailer", "What's Crossroads?"]]
-    binding.pry
+    exp_doc_titles = [["Article A1 B1 X1"], ["Article B2"]]
     page_doc_titles = @site.pages.collect { |d| d.data['articles']['docs'].collect(&:title) }
     expect(page_doc_titles).to match_array(exp_doc_titles)
   end

--- a/vendor/gems/article-tags/spec/unit/page_builder_spec.rb
+++ b/vendor/gems/article-tags/spec/unit/page_builder_spec.rb
@@ -13,33 +13,35 @@ describe Jekyll::ArticleTags::PageBuilder do
   it 'should build out an array of article categories and tags accessible to site config' do
     exp_article_filters = [
       {
-        "title" => "Category A",
-        "slug" => "cat-a",
-        "tags" => [
-          {
-            "title" => "Tag A1",
-            "slug" => "tag-a1",
-            "url" => "/articles/tags/cat-a+tag-a1"
-          }
-        ]
+        "category_title" => "Category A",
+        "category_slug" => "cat-a",
+        "tag_title" => "Tag A1",
+        "tag_slug" => "tag-a1",
+        "title" => "Tag A1",
+        "slug" => "cat-a+tag-a1",
+        "url" => "/articles/filters/cat-a+tag-a1"
+      },
+      {
+        "category_title" => "Category B",
+        "category_slug" => "cat-b",
+        "tag_title" => "Tag B2",
+        "tag_slug" => "tag-b2",
+        "title" => "Tag B2",
+        "slug" => "cat-b+tag-b2",
+        "url" => "/articles/filters/cat-b+tag-b2"
       }
     ]
     expect(@site.config['article_filters']).to match_array(exp_article_filters)
   end
 
-  it 'creates a page only for tags featured by a category' do
-    pending
-    raise "Create the page"
-
-    exp_page_data = ['Collection #1']
+  it 'creates a page only for tags featured by a category and applied to an article' do
+    exp_page_data = ['Tag A1', 'Tag B2']
     expect(@site.pages.collect { |p| p.data['title'] }).to match_array(exp_page_data)
   end
 
   it 'runs the paginator' do
-    pending
-    raise "Run the paginator"
-
     exp_doc_titles = [["Powerhouse Trailer", "What's Crossroads?"]]
+    binding.pry
     page_doc_titles = @site.pages.collect { |d| d.data['articles']['docs'].collect(&:title) }
     expect(page_doc_titles).to match_array(exp_doc_titles)
   end


### PR DESCRIPTION
Adds the logic and front-end links (unformatted) for filtering articles by featured tags.

Note that an article must belong to the category and have the tag for it to show up in the list.

I wanted to combine this feature with video-tags and build an abstracted gem. But they are just different enough that it didn't seem worth the effort at this point. Perhaps if filtering pops up for another media type.

I also chose a URL structure I'm not totally happy with. It looks like `/articles/filters/[cat_slug]+[tag_slug]`. For example, `/articles/filters/culture+mental-health`. That way we get the category and the tag represented in the URL but it doesn't have to be a super long URL.

As a consequence of a nested URL, I've added a redirect for /articles/filters to go back to /articles (i.e. when a filter slug is missing).

---

_Note that we may not want to merge this story until the styles are updated._