### PR TITLE
US16406 - Topics Featured Tag(s)

### DIFF
--- a/_plugins/generators/subtopics_generator.rb
+++ b/_plugins/generators/subtopics_generator.rb
@@ -53,7 +53,7 @@ module Jekyll
           { 'tag' => tag, 'media' => media }
         end
         # Set `tags` to be all associated tags used within the topic.
-        topic.data['tags'] = topic_tags
+        topic.data['all_tags'] = topic_tags
       end
     end
 

--- a/_plugins/generators/subtopics_generator.rb
+++ b/_plugins/generators/subtopics_generator.rb
@@ -53,7 +53,7 @@ module Jekyll
           { 'tag' => tag, 'media' => media }
         end
         # Set `tags` to be all associated tags used within the topic.
-        topic.data['all_tags'] = topic_tags
+        topic.data['tags'] = topic_tags
       end
     end
 

--- a/topics.html
+++ b/topics.html
@@ -28,7 +28,7 @@ title: Topics
             <a href="{{ topic.url }}">{{ topic.title }}</a>
           </h2>
           <ul class="list-unstyled">
-            {% for tag in topic.tags %}
+            {% for tag in topic.featured_tags %}
               <li>
                 <a href="/tags/{{ tag.slug }}/" class="topic-card-link">{{ tag.title | capitalize }}</a>
               </li>


### PR DESCRIPTION
Uses `topic.featured_tag` to list the tags on the /topics page.

I didn't adjust the height of the columns, but it looks a bit odd as it stands now. I'm open to suggestions, but it also doesn't have great data in it, so it doesn't reflect what we'll see in production. That is always something we can decide during demo. Or I can make content changes manually in int and we can test after this is merged. Doesn't matter to me.