### PR TITLE
DE6431 reduce title size on /articles and remove extra spacing

### DIFF
--- a/_includes/_article_index.html
+++ b/_includes/_article_index.html
@@ -1,8 +1,8 @@
 <div data-page="articles">
   <div class="row" data-page-number="{{ page.articles.page }}">
     {% for item in page.articles.docs %}
-    <div class="col-sm-6 push-bottom">
-      {% include _overlay-card.html collection="articles" %}
+    <div class="col-sm-6">
+      {% include _overlay-card.html collection="articles" title="h2" %}
     </div>
     {% endfor %}
   </div>

--- a/_includes/_overlay-card.html
+++ b/_includes/_overlay-card.html
@@ -19,7 +19,7 @@
 
   <div class="overlay-card-content">
     <p class="overlay-card-category">{{ item.category.title }}</p>
-    <h2 class="overlay-card-title">{{ item.title | truncate: 55 }}</h2>
+    <h2 class="overlay-card-title {% if include.title == 'h2' %}font-size-h2{% endif %}">{{ item.title | truncate: 55 }}</h2>
     <p class="overlay-card-author">{{ item.author.full_name }}</p>
 
     {% include _media-label.html source=item %}


### PR DESCRIPTION
## Problem
Title is too big on /articles with the new side bar and there's too much spacing between card rows

## Solution
- Remove `.push-bottom` from the `.col-sm-6` div
- add `font-size-h2` to card-title

### Corresponding Branch
none

## Testing
https://deploy-preview-521--crds-mediaint.netlify.com/articles/