### PR TITLE
de6437 interaction-heart-does-not-toggle

### DIFF
--- a/_includes/_footer-script.html
+++ b/_includes/_footer-script.html
@@ -11,4 +11,5 @@
 {% include _monetate-body.html %}
 
 {% javascript_link_tag page.js_manifest %}
-<script src="https://unpkg.com/crds-components@0.0.3/dist/crds-components.js"></script>
+
+<script src="https://unpkg.com/crds-components@0.0.4/dist/crds-components.js"></script>


### PR DESCRIPTION
update crds-components to version 0.0.4

## Problem
On mobile, the fill color does not revert back to the inactive/unfilled state. 

## Solution
update crds-components to version `0.0.4`

### Corresponding Branch
https://github.com/crdschurch/crds-components/pull/4
